### PR TITLE
feat: add DLX translation provider

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -77,12 +77,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "Enter a DLX-compatible endpoint (self-hosted or a public instance — see the wiki for options).",
+        "message": "Enter a DLX-compatible endpoint (self-hosted or a public instance). See the wiki for options.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Test Connection",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Translation Mode",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Batch (one request per song)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Per line (one request per lyric line)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "API Endpoint URL",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -68,6 +68,22 @@
         "message": "Custom AI (OpenAI-compatible)",
         "description": "Custom AI provider option"
     },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "DLX Endpoint URL",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "Enter a DLX-compatible endpoint (self-hosted or a public instance — see the wiki for options).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Test Connection",
+        "description": "Button to test DLX endpoint connection"
+    },
     "aiEndpoint": {
         "message": "API Endpoint URL",
         "description": "Label for AI API endpoint input"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "Introduce un endpoint compatible con DLX (autoalojado o una instancia pública — consulta la wiki para opciones).",
+        "message": "Introduce un endpoint compatible con DLX (autoalojado o una instancia pública). Consulta la wiki para ver opciones.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Probar conexión",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Modo de traducción",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Por lotes (una solicitud por canción)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Línea por línea (una solicitud por línea)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "URL del endpoint de la API",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -9,50 +9,170 @@
     },
     "targetLanguage": {
         "message": "Idioma de destino",
-        "description": "Idioma de destino"
+        "description": "Target language"
     },
     "applyLanguage": {
         "message": "Aplicar selección de idioma",
-        "description": "Aplicar selección de idioma"
+        "description": "Apply language selection"
     },
     "lyricsMode": {
         "message": "Modo de visualización de letras",
-        "description": "Modo de visualización de letras"
+        "description": "Lyrics mode"
     },
     "along": {
         "message": "Mostrar letras traducidas junto a las originales",
-        "description": "Mostrar letras traducidas junto a las originales"
+        "description": "Show translated lyrics along original"
     },
     "replace": {
         "message": "Reemplazar letras con la traducción",
-        "description": "Reemplazar letras con la traducción"
+        "description": "Replace lyrics with translation"
     },
     "lyricsSize": {
         "message": "Tamaño de fuente de las letras traducidas",
-        "description": "Tamaño de fuente de las letras traducidas"
+        "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 ¡Activa el botón de traducción en la barra de control del reproductor!",
-        "description": "Consejo sobre cómo activar"
+        "message": "- 🎵 ¡Activa el botón de traducción en la barra de control del reproductor! ",
+        "description": "toggle tip"
     },
     "githubRepo": {
         "message": "¡Revisa el repositorio de GitHub de código abierto!",
-        "description": "Repositorio de GitHub"
+        "description": "github repo"
     },
     "reviewLink": {
         "message": "★ ¡Deja una reseña!",
-        "description": "Enlace para dejar una reseña en la Chrome Web Store"
+        "description": "Chrome Web Store review link"
     },
     "translateToggle": {
         "message": "Activar Traducción",
-        "description": "Interruptor para activar/desactivar la traducción"
+        "description": "Toggle for enabling/disabling translation"
     },
     "translationOn": {
         "message": "Activado",
-        "description": "Estado activado de la traducción"
+        "description": "Translation toggle - on state"
     },
     "translationOff": {
         "message": "Desactivado",
-        "description": "Estado desactivado de la traducción"
+        "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "Proveedor de traducción",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google Translate",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "IA personalizada (compatible con OpenAI)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "URL del endpoint de DLX",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "Introduce un endpoint compatible con DLX (autoalojado o una instancia pública — consulta la wiki para opciones).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Probar conexión",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "URL del endpoint de la API",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions se añadirá a esta URL",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "Clave de API",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "Nombre del modelo",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "Probar conexión",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "¡Conexión exitosa!",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "Conexión fallida. Revisa tu configuración.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "Probando...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "Traduciendo con IA...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "Modo de razonamiento",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "Activado",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "Desactivado",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "Vista previa instantánea",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "Activado",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "Desactivado",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "Borrar caché de la canción actual",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "Borrar toda la caché",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "Depuración",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "Borrar almacenamiento de la extensión",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "Borra todos los ajustes guardados: idioma de destino, modo y tamaño de fuente de las letras, proveedor de traducción y tu endpoint de IA, clave de API, modelo y conmutadores. La extensión vuelve a los valores predeterminados.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "Haz clic de nuevo para confirmar",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -9,50 +9,170 @@
     },
     "targetLanguage": {
         "message": "Langue cible",
-        "description": "Langue cible"
+        "description": "Target language"
     },
     "applyLanguage": {
         "message": "Appliquer la sélection de langue",
-        "description": "Appliquer la sélection de langue"
+        "description": "Apply language selection"
     },
     "lyricsMode": {
         "message": "Mode d'affichage des paroles",
-        "description": "Mode d'affichage des paroles"
+        "description": "Lyrics mode"
     },
     "along": {
         "message": "Afficher les paroles traduites avec les originales",
-        "description": "Afficher les paroles traduites avec les originales"
+        "description": "Show translated lyrics along original"
     },
     "replace": {
         "message": "Remplacer les paroles par la traduction",
-        "description": "Remplacer les paroles par la traduction"
+        "description": "Replace lyrics with translation"
     },
     "lyricsSize": {
         "message": "Taille de la police des paroles traduites",
-        "description": "Taille de la police des paroles traduites"
+        "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 Activez le bouton de traduction dans la barre de contrôle du lecteur !",
-        "description": "Astuce pour l'activation"
+        "message": "- 🎵 Activez le bouton de traduction dans la barre de contrôle du lecteur ! ",
+        "description": "toggle tip"
     },
     "githubRepo": {
         "message": "Consultez le dépôt GitHub open source !",
-        "description": "Dépôt GitHub"
+        "description": "github repo"
     },
     "reviewLink": {
         "message": "★ Laissez un avis !",
-        "description": "Lien pour laisser un avis sur le Chrome Web Store"
+        "description": "Chrome Web Store review link"
     },
     "translateToggle": {
         "message": "Activer la Traduction",
-        "description": "Bascule pour activer/désactiver la traduction"
+        "description": "Toggle for enabling/disabling translation"
     },
     "translationOn": {
         "message": "Activé",
-        "description": "État activé de la traduction"
+        "description": "Translation toggle - on state"
     },
     "translationOff": {
         "message": "Désactivé",
-        "description": "État désactivé de la traduction"
+        "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "Fournisseur de traduction",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google Translate",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "IA personnalisée (compatible OpenAI)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "URL de l'endpoint DLX",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "Saisissez un endpoint compatible DLX (auto-hébergé ou une instance publique — voir le wiki pour les options).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Tester la connexion",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "URL de l'endpoint de l'API",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions sera ajouté à cette URL",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "Clé API",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "Nom du modèle",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "Tester la connexion",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "Connexion réussie !",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "Échec de la connexion. Vérifiez vos paramètres.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "Test en cours...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "Traduction par IA en cours...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "Mode de raisonnement",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "Activé",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "Désactivé",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "Aperçu instantané",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "Activé",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "Désactivé",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "Vider le cache de la chanson actuelle",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "Vider tout le cache",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "Débogage",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "Vider le stockage de l'extension",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "Efface tous les réglages sauvegardés : langue cible, mode et taille de police des paroles, fournisseur de traduction, ainsi que votre endpoint IA, clé API, modèle et boutons. L'extension revient aux valeurs par défaut.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "Cliquez à nouveau pour confirmer",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "Saisissez un endpoint compatible DLX (auto-hébergé ou une instance publique — voir le wiki pour les options).",
+        "message": "Saisissez un endpoint compatible DLX (auto-hébergé ou une instance publique). Voir le wiki pour les options.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Tester la connexion",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Mode de traduction",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Par lot (une requête par chanson)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Ligne par ligne (une requête par ligne)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "URL de l'endpoint de l'API",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "Masukkan endpoint yang kompatibel dengan DLX (self-hosted atau instance publik — lihat wiki untuk pilihannya).",
+        "message": "Masukkan endpoint yang kompatibel dengan DLX (self-hosted atau instance publik). Lihat wiki untuk pilihannya.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Tes Koneksi",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Mode Terjemahan",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Batch (satu permintaan per lagu)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Per baris (satu permintaan per baris lirik)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "URL Endpoint API",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1,7 +1,7 @@
 {
     "extName": {
         "message": "Translatify - Terjemahkan Lirik Spotify",
-        "description": "Nama ekstensi"
+        "description": "Extension name"
     },
     "extDesc": {
         "message": "Terjemahkan lirik Spotify secara instan ke dalam bahasa Anda secara real-time.",
@@ -9,50 +9,170 @@
     },
     "targetLanguage": {
         "message": "Bahasa tujuan",
-        "description": "Bahasa tujuan"
+        "description": "Target language"
     },
     "applyLanguage": {
         "message": "Terapkan pilihan bahasa",
-        "description": "Terapkan pilihan bahasa"
+        "description": "Apply language selection"
     },
     "lyricsMode": {
         "message": "Mode lirik",
-        "description": "Mode lirik"
+        "description": "Lyrics mode"
     },
     "along": {
         "message": "Tampilkan lirik terjemahan bersama yang asli",
-        "description": "Tampilkan lirik terjemahan bersama yang asli"
+        "description": "Show translated lyrics along original"
     },
     "replace": {
         "message": "Gantikan lirik dengan terjemahan",
-        "description": "Gantikan lirik dengan terjemahan"
+        "description": "Replace lyrics with translation"
     },
     "lyricsSize": {
         "message": "Ukuran font lirik terjemahan",
-        "description": "Ukuran font lirik terjemahan"
+        "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 Aktifkan tombol terjemahan di bilah kontrol pemutar!",
-        "description": "Tip tombol terjemahan"
+        "message": "- 🎵 Aktifkan tombol terjemahan di bilah kontrol pemutar! ",
+        "description": "toggle tip"
     },
     "githubRepo": {
         "message": "Lihat repositori GitHub sumber terbuka!",
-        "description": "Repositori GitHub"
+        "description": "github repo"
     },
     "reviewLink": {
         "message": "★ Tinggalkan ulasan!",
-        "description": "Tautan ulasan"
+        "description": "Chrome Web Store review link"
     },
     "translateToggle": {
         "message": "Aktifkan Terjemahan",
-        "description": "Tombol aktif/nonaktif terjemahan"
+        "description": "Toggle for enabling/disabling translation"
     },
     "translationOn": {
         "message": "Aktif",
-        "description": "Terjemahan aktif"
+        "description": "Translation toggle - on state"
     },
     "translationOff": {
         "message": "Nonaktif",
-        "description": "Terjemahan nonaktif"
+        "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "Penyedia Terjemahan",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google Translate",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "AI Kustom (kompatibel OpenAI)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "URL Endpoint DLX",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "Masukkan endpoint yang kompatibel dengan DLX (self-hosted atau instance publik — lihat wiki untuk pilihannya).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Tes Koneksi",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "URL Endpoint API",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions akan ditambahkan ke URL ini",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "Kunci API",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "Nama Model",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "Tes Koneksi",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "Koneksi berhasil!",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "Koneksi gagal. Periksa pengaturan Anda.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "Menguji...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "Menerjemahkan dengan AI...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "Mode Berpikir",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "Aktif",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "Nonaktif",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "Pratinjau instan",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "Aktif",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "Nonaktif",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "Hapus cache lagu saat ini",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "Hapus semua cache",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "Debug",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "Hapus penyimpanan ekstensi",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "Menghapus semua pengaturan tersimpan: bahasa tujuan, mode lirik & ukuran font, penyedia terjemahan, serta endpoint AI, kunci API, model, dan tombol Anda. Ekstensi kembali ke pengaturan default.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "Klik sekali lagi untuk konfirmasi",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "DLX 互換のエンドポイントを入力してください（自己ホストまたは公開インスタンス — オプションは wiki を参照）。",
+        "message": "DLX 互換のエンドポイントを入力してください（自己ホストまたは公開インスタンス）。詳しくは wiki を参照してください。",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "接続テスト",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "翻訳モード",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "バッチ（1曲につき1リクエスト）",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "行ごと（歌詞1行につき1リクエスト）",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "API エンドポイント URL",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -32,7 +32,7 @@
         "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 プレイヤーのコントロールバーにある翻訳ボタンで切り替え！",
+        "message": "- 🎵 プレイヤーのコントロールバーにある翻訳ボタンで切り替え！ ",
         "description": "toggle tip"
     },
     "githubRepo": {
@@ -54,5 +54,125 @@
     "translationOff": {
         "message": "オフ",
         "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "翻訳プロバイダー",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google 翻訳",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "カスタム AI（OpenAI 互換）",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "DLX エンドポイント URL",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "DLX 互換のエンドポイントを入力してください（自己ホストまたは公開インスタンス — オプションは wiki を参照）。",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "接続テスト",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "API エンドポイント URL",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions がこの URL に追加されます",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "API キー",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "モデル名",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "接続テスト",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "接続に成功しました！",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "接続に失敗しました。設定を確認してください。",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "テスト中...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "AI で翻訳中...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "思考モード",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "オン",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "オフ",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "インスタントプレビュー",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "オン",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "オフ",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "現在の曲のキャッシュをクリア",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "すべてのキャッシュをクリア",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "デバッグ",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "拡張機能のストレージをクリア",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "保存されたすべての設定を消去します：対象言語、歌詞モードとフォントサイズ、翻訳プロバイダー、および AI エンドポイント、API キー、モデル、トグル。拡張機能はデフォルトにリセットされます。",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "もう一度クリックして確認",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -32,7 +32,7 @@
         "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 플레이어 컨트롤 바의 번역 버튼으로 설정해 보세요!",
+        "message": "- 🎵 플레이어 컨트롤 바의 번역 버튼으로 설정해 보세요! ",
         "description": "toggle tip"
     },
     "githubRepo": {
@@ -54,5 +54,125 @@
     "translationOff": {
         "message": "끔",
         "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "번역 제공자",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google 번역",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "커스텀 AI (OpenAI 호환)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "DLX 엔드포인트 URL",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "DLX 호환 엔드포인트를 입력하세요 (자체 호스팅 또는 공개 인스턴스 — 옵션은 wiki 참조).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "연결 테스트",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "API 엔드포인트 URL",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions 이 URL에 추가됩니다",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "API 키",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "모델 이름",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "연결 테스트",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "연결 성공!",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "연결 실패. 설정을 확인하세요.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "테스트 중...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "AI로 번역 중...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "사고 모드",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "켬",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "끔",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "인스턴트 미리보기",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "켬",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "끔",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "현재 곡 캐시 지우기",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "모든 캐시 지우기",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "디버그",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "확장 프로그램 저장공간 지우기",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "저장된 모든 설정을 삭제합니다: 대상 언어, 가사 모드 및 글꼴 크기, 번역 제공자, 그리고 AI 엔드포인트, API 키, 모델 및 토글. 확장 프로그램이 기본값으로 재설정됩니다.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "다시 클릭하여 확인하세요",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "DLX 호환 엔드포인트를 입력하세요 (자체 호스팅 또는 공개 인스턴스 — 옵션은 wiki 참조).",
+        "message": "DLX 호환 엔드포인트를 입력하세요 (자체 호스팅 또는 공개 인스턴스). 옵션은 wiki를 참조하세요.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "연결 테스트",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "번역 모드",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "일괄 (곡당 요청 1회)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "행별 (가사 한 줄당 요청 1회)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "API 엔드포인트 URL",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "Insira um endpoint compatível com DLX (auto-hospedado ou uma instância pública — consulte a wiki para opções).",
+        "message": "Insira um endpoint compatível com DLX (auto-hospedado ou uma instância pública). Consulte a wiki para ver as opções.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Testar conexão",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Modo de tradução",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Em lote (uma solicitação por música)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Linha a linha (uma solicitação por linha)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "URL do endpoint da API",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,58 +1,178 @@
 {
     "extName": {
         "message": "Translatify - Traduzir letras do Spotify",
-        "description": "Nome da extensão"
+        "description": "Extension name"
     },
     "extDesc": {
         "message": "Traduza instantaneamente letras do Spotify para seu idioma em tempo real.",
-        "description": "Descrição da extensão"
+        "description": "Extension description"
     },
     "targetLanguage": {
         "message": "Idioma de destino",
-        "description": "Idioma de destino"
+        "description": "Target language"
     },
     "applyLanguage": {
         "message": "Aplicar seleção de idioma",
-        "description": "Aplicar seleção de idioma"
+        "description": "Apply language selection"
     },
     "lyricsMode": {
         "message": "Modo de letras",
-        "description": "Modo de letras"
+        "description": "Lyrics mode"
     },
     "along": {
         "message": "Mostrar letras traduzidas junto com as originais",
-        "description": "Mostrar letras traduzidas junto com as originais"
+        "description": "Show translated lyrics along original"
     },
     "replace": {
         "message": "Substituir letras pela tradução",
-        "description": "Substituir letras pela tradução"
+        "description": "Replace lyrics with translation"
     },
     "lyricsSize": {
         "message": "Tamanho da fonte das letras traduzidas",
-        "description": "Tamanho da fonte das letras traduzidas"
+        "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 Ative o botão de tradução na barra de controle do player!",
-        "description": "Dica de botão de tradução"
+        "message": "- 🎵 Ative o botão de tradução na barra de controle do player! ",
+        "description": "toggle tip"
     },
     "githubRepo": {
         "message": "Confira o repositório de código aberto no GitHub!",
-        "description": "Repositório GitHub"
+        "description": "github repo"
     },
     "reviewLink": {
         "message": "★ Deixe uma avaliação!",
-        "description": "Link para avaliação"
+        "description": "Chrome Web Store review link"
     },
     "translateToggle": {
         "message": "Ativar tradução",
-        "description": "Alternar tradução"
+        "description": "Toggle for enabling/disabling translation"
     },
     "translationOn": {
         "message": "Ligado",
-        "description": "Tradução ativada"
+        "description": "Translation toggle - on state"
     },
     "translationOff": {
         "message": "Desligado",
-        "description": "Tradução desativada"
+        "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "Provedor de tradução",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google Translate",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "IA personalizada (compatível com OpenAI)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "URL do endpoint do DLX",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "Insira um endpoint compatível com DLX (auto-hospedado ou uma instância pública — consulte a wiki para opções).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Testar conexão",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "URL do endpoint da API",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions será anexado a esta URL",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "Chave de API",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "Nome do modelo",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "Testar conexão",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "Conexão bem-sucedida!",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "Conexão falhou. Verifique suas configurações.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "Testando...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "Traduzindo com IA...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "Modo de raciocínio",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "Ligado",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "Desligado",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "Pré-visualização instantânea",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "Ligado",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "Desligado",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "Limpar cache da música atual",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "Limpar todo o cache",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "Depuração",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "Limpar armazenamento da extensão",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "Apaga todas as configurações salvas: idioma de destino, modo e tamanho da fonte das letras, provedor de tradução e seu endpoint de IA, chave de API, modelo e alternadores. A extensão volta aos padrões.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "Clique novamente para confirmar",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "Introduza um endpoint compatível com DLX (auto-hospedado ou uma instância pública — consulte a wiki para opções).",
+        "message": "Introduza um endpoint compatível com DLX (auto-hospedado ou uma instância pública). Consulte a wiki para ver as opções.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Testar ligação",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Modo de tradução",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Em lote (um pedido por música)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Linha a linha (um pedido por linha)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "URL do endpoint da API",

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -1,58 +1,178 @@
 {
     "extName": {
         "message": "Translatify - Traduzir letras do Spotify",
-        "description": "Nome da extensão"
+        "description": "Extension name"
     },
     "extDesc": {
-        "message": "Traduza instantaneamente letras do Spotify para seu idioma em tempo real.",
-        "description": "Descrição da extensão"
+        "message": "Traduza instantaneamente letras do Spotify para o seu idioma em tempo real.",
+        "description": "Extension description"
     },
     "targetLanguage": {
         "message": "Idioma de destino",
-        "description": "Idioma de destino"
+        "description": "Target language"
     },
     "applyLanguage": {
         "message": "Aplicar seleção de idioma",
-        "description": "Aplicar seleção de idioma"
+        "description": "Apply language selection"
     },
     "lyricsMode": {
         "message": "Modo de letras",
-        "description": "Modo de letras"
+        "description": "Lyrics mode"
     },
     "along": {
         "message": "Mostrar letras traduzidas junto com as originais",
-        "description": "Mostrar letras traduzidas junto com as originais"
+        "description": "Show translated lyrics along original"
     },
     "replace": {
         "message": "Substituir letras pela tradução",
-        "description": "Substituir letras pela tradução"
+        "description": "Replace lyrics with translation"
     },
     "lyricsSize": {
         "message": "Tamanho da fonte das letras traduzidas",
-        "description": "Tamanho da fonte das letras traduzidas"
+        "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 Ative o botão de tradução na barra de controle do player!",
-        "description": "Dica de botão de tradução"
+        "message": "- 🎵 Ative o botão de tradução na barra de controlo do reprodutor! ",
+        "description": "toggle tip"
     },
     "githubRepo": {
-        "message": "Confira o repositório de código aberto no GitHub!",
-        "description": "Repositório GitHub"
+        "message": "Consulte o repositório de código aberto no GitHub!",
+        "description": "github repo"
     },
     "reviewLink": {
         "message": "★ Deixe uma avaliação!",
-        "description": "Link para avaliação"
+        "description": "Chrome Web Store review link"
     },
     "translateToggle": {
         "message": "Ativar tradução",
-        "description": "Alternar tradução"
+        "description": "Toggle for enabling/disabling translation"
     },
     "translationOn": {
         "message": "Ligado",
-        "description": "Tradução ativada"
+        "description": "Translation toggle - on state"
     },
     "translationOff": {
         "message": "Desligado",
-        "description": "Tradução desativada"
+        "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "Fornecedor de tradução",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google Translate",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "IA personalizada (compatível com OpenAI)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "URL do endpoint do DLX",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "Introduza um endpoint compatível com DLX (auto-hospedado ou uma instância pública — consulte a wiki para opções).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Testar ligação",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "URL do endpoint da API",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions será anexado a este URL",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "Chave de API",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "Nome do modelo",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "Testar ligação",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "Ligação bem-sucedida!",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "Ligação falhou. Verifique as suas definições.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "A testar...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "A traduzir com IA...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "Modo de raciocínio",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "Ligado",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "Desligado",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "Pré-visualização instantânea",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "Ligado",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "Desligado",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "Limpar cache da música atual",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "Limpar toda a cache",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "Depuração",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "Limpar armazenamento da extensão",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "Apaga todas as definições guardadas: idioma de destino, modo e tamanho da fonte das letras, fornecedor de tradução e o seu endpoint de IA, chave de API, modelo e interruptores. A extensão volta aos predefinidos.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "Clique novamente para confirmar",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1,58 +1,178 @@
 {
     "extName": {
         "message": "Translatify - Spotify Şarkı Sözlerini Çevir",
-        "description": "Uzantı adı"
+        "description": "Extension name"
     },
     "extDesc": {
         "message": "Spotify şarkı sözlerini anında kendi dilinize gerçek zamanlı çevirin.",
-        "description": "Uzantı açıklaması"
+        "description": "Extension description"
     },
     "targetLanguage": {
         "message": "Hedef dil",
-        "description": "Hedef dil"
+        "description": "Target language"
     },
     "applyLanguage": {
         "message": "Dil seçimini uygula",
-        "description": "Dil seçimini uygula"
+        "description": "Apply language selection"
     },
     "lyricsMode": {
         "message": "Şarkı sözü modu",
-        "description": "Şarkı sözü modu"
+        "description": "Lyrics mode"
     },
     "along": {
         "message": "Çeviriyle birlikte orijinal sözleri göster",
-        "description": "Çeviriyle birlikte orijinal sözleri göster"
+        "description": "Show translated lyrics along original"
     },
     "replace": {
         "message": "Şarkı sözlerini çeviriyle değiştir",
-        "description": "Şarkı sözlerini çeviriyle değiştir"
+        "description": "Replace lyrics with translation"
     },
     "lyricsSize": {
         "message": "Çevirilen sözlerin yazı tipi boyutu",
-        "description": "Çevirilen sözlerin yazı tipi boyutu"
+        "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 Çeviri düğmesini oynatıcı kontrol çubuğunda aç!",
-        "description": "Çeviri ipucu"
+        "message": "- 🎵 Çeviri düğmesini oynatıcı kontrol çubuğunda aç! ",
+        "description": "toggle tip"
     },
     "githubRepo": {
         "message": "GitHub açık kaynak deposunu incele!",
-        "description": "GitHub deposu"
+        "description": "github repo"
     },
     "reviewLink": {
         "message": "★ Bir inceleme bırak!",
-        "description": "İnceleme bağlantısı"
+        "description": "Chrome Web Store review link"
     },
     "translateToggle": {
         "message": "Çeviriyi Etkinleştir",
-        "description": "Çeviri etkinleştirme/durdurma düğmesi"
+        "description": "Toggle for enabling/disabling translation"
     },
     "translationOn": {
         "message": "Açık",
-        "description": "Çeviri açık durumu"
+        "description": "Translation toggle - on state"
     },
     "translationOff": {
         "message": "Kapalı",
-        "description": "Çeviri kapalı durumu"
+        "description": "Translation toggle - off state"
+    },
+    "translationProvider": {
+        "message": "Çeviri Sağlayıcısı",
+        "description": "Label for translation provider selector"
+    },
+    "providerGoogle": {
+        "message": "Google Çeviri",
+        "description": "Google Translate provider option"
+    },
+    "providerCustomAI": {
+        "message": "Özel AI (OpenAI uyumlu)",
+        "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "DLX Uç Nokta URL'si",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "DLX uyumlu bir uç nokta girin (kendi kendine barındırılan veya genel bir örnek — seçenekler için wiki'ye bakın).",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "Bağlantıyı Test Et",
+        "description": "Button to test DLX endpoint connection"
+    },
+    "aiEndpoint": {
+        "message": "API Uç Nokta URL'si",
+        "description": "Label for AI API endpoint input"
+    },
+    "aiEndpointPlaceholder": {
+        "message": "https://api.openai.com/v1",
+        "description": "Placeholder for AI endpoint input"
+    },
+    "aiEndpointHint": {
+        "message": "/chat/completions bu URL'nin sonuna eklenecektir",
+        "description": "Hint explaining that /chat/completions is appended to the endpoint URL"
+    },
+    "aiApiKey": {
+        "message": "API Anahtarı",
+        "description": "Label for AI API key input"
+    },
+    "aiModel": {
+        "message": "Model Adı",
+        "description": "Label for AI model name input"
+    },
+    "aiModelPlaceholder": {
+        "message": "gpt-4o-mini",
+        "description": "Placeholder for AI model input"
+    },
+    "aiTestConnection": {
+        "message": "Bağlantıyı Test Et",
+        "description": "Button to test AI API connection"
+    },
+    "aiTestSuccess": {
+        "message": "Bağlantı başarılı!",
+        "description": "Success message for AI connection test"
+    },
+    "aiTestFail": {
+        "message": "Bağlantı başarısız. Ayarlarınızı kontrol edin.",
+        "description": "Failure message for AI connection test"
+    },
+    "aiTestInProgress": {
+        "message": "Test ediliyor...",
+        "description": "Progress message for AI connection test"
+    },
+    "aiTranslating": {
+        "message": "AI ile çevriliyor...",
+        "description": "Message shown while AI translation is in progress"
+    },
+    "aiThinkMode": {
+        "message": "Düşünme Modu",
+        "description": "Label for AI thinking mode toggle"
+    },
+    "thinkModeOn": {
+        "message": "Açık",
+        "description": "Thinking mode toggle - on state"
+    },
+    "thinkModeOff": {
+        "message": "Kapalı",
+        "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "Anlık önizleme",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "Açık",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "Kapalı",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "Mevcut şarkı önbelleğini temizle",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "Tüm önbelleği temizle",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "Hata Ayıklama",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "Uzantı depolamasını temizle",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "Kaydedilen tüm ayarları siler: hedef dil, şarkı sözü modu ve yazı tipi boyutu, çeviri sağlayıcısı ve AI uç noktanız, API anahtarınız, modeliniz ve düğmeleriniz. Uzantı varsayılanlara sıfırlanır.",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "Onaylamak için tekrar tıklayın",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "DLX uyumlu bir uç nokta girin (kendi kendine barındırılan veya genel bir örnek — seçenekler için wiki'ye bakın).",
+        "message": "DLX uyumlu bir uç nokta girin (kendi barındırdığınız veya genel bir örnek). Seçenekler için wiki'ye bakın.",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "Bağlantıyı Test Et",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "Çeviri Modu",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "Toplu (şarkı başına tek istek)",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "Satır satır (her söz satırı için bir istek)",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "API Uç Nokta URL'si",

--- a/_locales/zh-CN/messages.json
+++ b/_locales/zh-CN/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "请输入兼容 DLX 的端点（可自建，或使用公共实例——详见 wiki）。",
+        "message": "请输入兼容 DLX 的端点（可自建，或使用公共实例）。详见 wiki。",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "测试连接",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "翻译模式",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "批量（每首歌一次请求）",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "逐行（每行歌词一次请求）",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "API 端点地址",

--- a/_locales/zh-CN/messages.json
+++ b/_locales/zh-CN/messages.json
@@ -32,7 +32,7 @@
         "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 点击播放控制条上的翻译按钮进行切换！",
+        "message": "- 🎵 点击播放控制条上的翻译按钮进行切换！ ",
         "description": "toggle tip"
     },
     "githubRepo": {
@@ -66,6 +66,22 @@
     "providerCustomAI": {
         "message": "自定义 AI（兼容 OpenAI）",
         "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "DLX 端点地址",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "请输入兼容 DLX 的端点（可自建，或使用公共实例——详见 wiki）。",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "测试连接",
+        "description": "Button to test DLX endpoint connection"
     },
     "aiEndpoint": {
         "message": "API 端点地址",
@@ -122,5 +138,41 @@
     "thinkModeOff": {
         "message": "关闭",
         "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "即时预览",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "开启",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "关闭",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "清除当前歌曲缓存",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "清除所有缓存",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "调试",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "清除扩展存储",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "清除所有已保存的设置：目标语言、歌词模式和字体大小、翻译提供商，以及您的 AI 端点、API 密钥、模型和开关。扩展将恢复为默认设置。",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "再次点击以确认",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -76,12 +76,24 @@
         "description": "Label for DLX endpoint input"
     },
     "dlxEndpointHint": {
-        "message": "请输入兼容 DLX 的端点（可自建，或使用公共实例——详见 wiki）。",
+        "message": "请输入兼容 DLX 的端点（可自建，或使用公共实例）。详见 wiki。",
         "description": "Hint explaining the DLX endpoint field"
     },
     "dlxTestConnection": {
         "message": "测试连接",
         "description": "Button to test DLX endpoint connection"
+    },
+    "dlxTranslationMode": {
+        "message": "翻译模式",
+        "description": "Label for the DLX translation mode selector"
+    },
+    "dlxModeBatch": {
+        "message": "批量（每首歌一次请求）",
+        "description": "DLX mode option: batch (one request per song)"
+    },
+    "dlxModePerLine": {
+        "message": "逐行（每行歌词一次请求）",
+        "description": "DLX mode option: per line (one request per lyric line)"
     },
     "aiEndpoint": {
         "message": "API 端点地址",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -32,7 +32,7 @@
         "description": "Font size of translated lyrics"
     },
     "toggleTip": {
-        "message": "- 🎵 点击播放控制条上的翻译按钮进行切换！",
+        "message": "- 🎵 点击播放控制条上的翻译按钮进行切换！ ",
         "description": "toggle tip"
     },
     "githubRepo": {
@@ -66,6 +66,22 @@
     "providerCustomAI": {
         "message": "自定义 AI（兼容 OpenAI）",
         "description": "Custom AI provider option"
+    },
+    "providerDlx": {
+        "message": "DLX",
+        "description": "DLX provider option"
+    },
+    "dlxEndpoint": {
+        "message": "DLX 端点地址",
+        "description": "Label for DLX endpoint input"
+    },
+    "dlxEndpointHint": {
+        "message": "请输入兼容 DLX 的端点（可自建，或使用公共实例——详见 wiki）。",
+        "description": "Hint explaining the DLX endpoint field"
+    },
+    "dlxTestConnection": {
+        "message": "测试连接",
+        "description": "Button to test DLX endpoint connection"
     },
     "aiEndpoint": {
         "message": "API 端点地址",
@@ -122,5 +138,41 @@
     "thinkModeOff": {
         "message": "关闭",
         "description": "Thinking mode toggle - off state"
+    },
+    "aiFailover": {
+        "message": "即时预览",
+        "description": "Label for the AI failover toggle"
+    },
+    "failoverOn": {
+        "message": "开启",
+        "description": "Failover toggle - on state"
+    },
+    "failoverOff": {
+        "message": "关闭",
+        "description": "Failover toggle - off state"
+    },
+    "clearSongCache": {
+        "message": "清除当前歌曲缓存",
+        "description": "Button to clear the cached translations for the current song"
+    },
+    "clearAllCache": {
+        "message": "清除所有缓存",
+        "description": "Button to clear all cached translations"
+    },
+    "debugTitle": {
+        "message": "调试",
+        "description": "Title for the debug section"
+    },
+    "clearStorage": {
+        "message": "清除扩展存储",
+        "description": "Debug button to clear all saved extension settings"
+    },
+    "clearStorageHint": {
+        "message": "清除所有已保存的设置：目标语言、歌词模式和字体大小、翻译提供商，以及您的 AI 端点、API 密钥、模型和开关。扩展将恢复为默认设置。",
+        "description": "Explanation of what clearing the extension storage removes"
+    },
+    "confirmClear": {
+        "message": "再次点击以确认",
+        "description": "Confirmation prompt shown on a clear-cache button after the first click"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,8 @@
     "https://translate.googleapis.com/*"
   ],
   "optional_host_permissions": [
-    "https://*/*"
+    "https://*/*",
+    "http://*/*"
   ],
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
         "styles/translatify.css"
       ],
       "js": [
+        "scripts/providers.js",
         "scripts/translateButton.js",
         "scripts/lyricsTranslator.js",
         "scripts/main.js"

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -406,7 +406,8 @@ h4.subtitle {
     /* ==========================================================================
    AI settings
    ========================================================================== */
-    #aiSettings {
+    #aiSettings,
+    #dlxSettings {
         margin-top: 12px;
     }
 
@@ -439,13 +440,15 @@ h4.subtitle {
         margin-bottom: 10px;
     }
 
-    #aiTestConnection {
+    #aiTestConnection,
+    #dlxTestConnection {
         /* #applyLanguage gets 10px flex-gap from .optionDiv + 10px margin = 20px.
-       This button is nested in #aiSettings (no flex gap), so match with 20px. */
+       This button is nested in a provider panel (no flex gap), so match with 20px. */
         margin-top: 20px;
     }
 
-    #aiTestStatus {
+    #aiTestStatus,
+    #dlxTestStatus {
         display: block;
         text-align: center;
         margin-top: 8px;
@@ -454,19 +457,23 @@ h4.subtitle {
     }
 
     /* Collapse the reserved status line until a test message is shown, so there's
-   no extra blank space at the bottom of the AI provider section. */
-    #aiTestStatus:empty {
+   no extra blank space at the bottom of the provider section. */
+    #aiTestStatus:empty,
+    #dlxTestStatus:empty {
         display: none;
     }
 
-    #aiTestStatus.success {
+    #aiTestStatus.success,
+    #dlxTestStatus.success {
         color: var(--text);
     }
 
-    #aiTestStatus.error {
+    #aiTestStatus.error,
+    #dlxTestStatus.error {
         color: var(--error);
     }
 
-    #aiTestStatus.loading {
+    #aiTestStatus.loading,
+    #dlxTestStatus.loading {
         color: var(--warning);
     }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -64,9 +64,15 @@
         <h4 class="subtitle" data-locale="dlxEndpoint">DLX Endpoint URL</h4>
        
         <input type="text" id="dlxEndpoint" class="aiInput" placeholder="https://your-dlx-instance.example.com/translate">
-        <span class="aiHint" data-locale="dlxEndpointHint">Enter a DLX-compatible endpoint (self-hosted or a public instance — see the wiki for options).</span>
+        <span class="aiHint" data-locale="dlxEndpointHint">Enter a DLX-compatible endpoint (self-hosted or a public instance). See the wiki for options.</span>
         <button id="dlxTestConnection" data-locale="dlxTestConnection">Test Connection</button>
         <span id="dlxTestStatus"></span>
+
+        <h4 class="subtitle" data-locale="dlxTranslationMode">Translation Mode</h4>
+        <select id="dlxTranslationMode" class="selectOptions">
+          <option value="batch" data-locale="dlxModeBatch">Batch (one request per song)</option>
+          <option value="perline" data-locale="dlxModePerLine">Per line (one request per lyric line)</option>
+        </select>
       </div>
 
       <div id="aiSettings" style="display:none;">

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -56,8 +56,18 @@
       <h4 data-locale="translationProvider">Translation Provider</h4>
       <select name="translationProvider" id="translationProvider" class="selectOptions">
         <option value="google" data-locale="providerGoogle">Google Translate</option>
+        <option value="dlx" data-locale="providerDlx">DLX</option>
         <option value="customAI" data-locale="providerCustomAI">Custom AI (OpenAI-compatible)</option>
       </select>
+
+      <div id="dlxSettings" style="display:none;">
+        <h4 class="subtitle" data-locale="dlxEndpoint">DLX Endpoint URL</h4>
+       
+        <input type="text" id="dlxEndpoint" class="aiInput" placeholder="https://your-dlx-instance.example.com/translate">
+        <span class="aiHint" data-locale="dlxEndpointHint">Enter a DLX-compatible endpoint (self-hosted or a public instance — see the wiki for options).</span>
+        <button id="dlxTestConnection" data-locale="dlxTestConnection">Test Connection</button>
+        <span id="dlxTestStatus"></span>
+      </div>
 
       <div id="aiSettings" style="display:none;">
         <h4 class="subtitle" data-locale="aiEndpoint">API Endpoint URL</h4>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -317,6 +317,7 @@
 
   </div>
     <script src="localize.js"></script>
+    <script src="../scripts/providers.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -62,17 +62,17 @@
 
       <div id="dlxSettings" style="display:none;">
         <h4 class="subtitle" data-locale="dlxEndpoint">DLX Endpoint URL</h4>
-       
         <input type="text" id="dlxEndpoint" class="aiInput" placeholder="https://your-dlx-instance.example.com/translate">
         <span class="aiHint" data-locale="dlxEndpointHint">Enter a DLX-compatible endpoint (self-hosted or a public instance). See the wiki for options.</span>
-        <button id="dlxTestConnection" data-locale="dlxTestConnection">Test Connection</button>
-        <span id="dlxTestStatus"></span>
 
         <h4 class="subtitle" data-locale="dlxTranslationMode">Translation Mode</h4>
         <select id="dlxTranslationMode" class="selectOptions">
           <option value="batch" data-locale="dlxModeBatch">Batch (one request per song)</option>
           <option value="perline" data-locale="dlxModePerLine">Per line (one request per lyric line)</option>
         </select>
+
+        <button id="dlxTestConnection" data-locale="dlxTestConnection">Test Connection</button>
+        <span id="dlxTestStatus"></span>
       </div>
 
       <div id="aiSettings" style="display:none;">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -127,10 +127,15 @@ chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiMo
 });
 
 // Show the settings panel for the selected provider, hide the others.
+// Panels come from the registry (scripts/providers.js), so a new provider
+// only needs a panelId there plus its markup in popup.html.
 function updateProviderSettingsVisibility() {
     const provider = translationProvider.value;
-    aiSettings.style.display = provider === 'customAI' ? 'block' : 'none';
-    dlxSettings.style.display = provider === 'dlx' ? 'block' : 'none';
+    for (const [id, spec] of Object.entries(TRANSLATION_PROVIDERS)) {
+        if (!spec.panelId) continue;
+        const panel = document.getElementById(spec.panelId);
+        if (panel) panel.style.display = provider === id ? 'block' : 'none';
+    }
 }
 
 function sendToSpotifyTabs(message) {
@@ -182,30 +187,38 @@ dlxTranslationMode.addEventListener('change', async () => {
     sendToSpotifyTabs({ updateDlxTranslationMode: mode });
 });
 
+// Shared status rendering for the provider "Test Connection" buttons.
+function setTestStatus(el, state, detail) {
+    if (state === 'loading') {
+        el.textContent = chrome.i18n.getMessage('aiTestInProgress') || 'Testing...';
+        el.className = 'loading';
+    } else if (state === 'success') {
+        el.textContent = chrome.i18n.getMessage('aiTestSuccess') || 'Connection successful!';
+        el.className = 'success';
+    } else {
+        el.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + (detail ? ` (${detail})` : '');
+        el.className = 'error';
+    }
+}
+
 dlxTestConnection.addEventListener('click', async () => {
     const endpoint = dlxEndpoint.value.trim();
     if (endpoint) {
         const granted = await ensureHostPermission(endpoint);
         if (!granted) {
-            dlxTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ' (access to the endpoint was not granted)';
-            dlxTestStatus.className = 'error';
-            return;
+            return setTestStatus(dlxTestStatus, 'error', 'access to the endpoint was not granted');
         }
     }
-    dlxTestStatus.textContent = chrome.i18n.getMessage('aiTestInProgress') || 'Testing...';
-    dlxTestStatus.className = 'loading';
+    setTestStatus(dlxTestStatus, 'loading');
     try {
-        const response = await chrome.runtime.sendMessage({ type: 'TEST_DLX', endpoint });
+        const response = await chrome.runtime.sendMessage({ type: 'TEST_PROVIDER', provider: 'dlx', endpoint });
         if (response?.ok) {
-            dlxTestStatus.textContent = chrome.i18n.getMessage('aiTestSuccess') || 'Connection successful!';
-            dlxTestStatus.className = 'success';
+            setTestStatus(dlxTestStatus, 'success');
         } else {
-            dlxTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ` (${response?.error || 'unknown error'})`;
-            dlxTestStatus.className = 'error';
+            setTestStatus(dlxTestStatus, 'error', response?.error || 'unknown error');
         }
     } catch (e) {
-        dlxTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ` (${e.message})`;
-        dlxTestStatus.className = 'error';
+        setTestStatus(dlxTestStatus, 'error', e.message);
     }
 });
 
@@ -319,20 +332,15 @@ aiTestConnection.addEventListener('click', async () => {
     const model = aiModel.value.trim();
 
     if (!endpoint || !apiKey) {
-        aiTestStatus.textContent = chrome.i18n.getMessage('aiTestFail') || 'Connection failed. Check your settings.';
-        aiTestStatus.className = 'error';
-        return;
+        return setTestStatus(aiTestStatus, 'error');
     }
 
     const granted = await ensureHostPermission(endpoint);
     if (!granted) {
-        aiTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ' (access to the endpoint was not granted)';
-        aiTestStatus.className = 'error';
-        return;
+        return setTestStatus(aiTestStatus, 'error', 'access to the endpoint was not granted');
     }
 
-    aiTestStatus.textContent = chrome.i18n.getMessage('aiTestInProgress') || 'Testing...';
-    aiTestStatus.className = 'loading';
+    setTestStatus(aiTestStatus, 'loading');
 
     try {
         const baseUrl = endpoint.replace(/\/+$/, '');
@@ -355,24 +363,18 @@ aiTestConnection.addEventListener('click', async () => {
             try {
                 const data = await response.json();
                 if (data.choices || data.id || data.object) {
-                    aiTestStatus.textContent = chrome.i18n.getMessage('aiTestSuccess') || 'Connection successful!';
-                    aiTestStatus.className = 'success';
+                    setTestStatus(aiTestStatus, 'success');
                 } else {
-                    aiTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed. Check your settings.') + ' (unexpected response format)';
-                    aiTestStatus.className = 'error';
+                    setTestStatus(aiTestStatus, 'error', 'unexpected response format');
                 }
             } catch {
-                aiTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ' (endpoint returned non-JSON — check the URL includes the full API path, e.g. /v1)';
-                aiTestStatus.className = 'error';
+                setTestStatus(aiTestStatus, 'error', 'endpoint returned non-JSON; check the URL includes the full API path, e.g. /v1');
             }
         } else {
-            const errorText = await response.text();
-            aiTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ` (${response.status})`;
-            aiTestStatus.className = 'error';
+            setTestStatus(aiTestStatus, 'error', String(response.status));
         }
     } catch (e) {
-        aiTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ` (${e.message})`;
-        aiTestStatus.className = 'error';
+        setTestStatus(aiTestStatus, 'error', e.message);
     }
 });
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -18,6 +18,10 @@ const aiTestConnection = document.getElementById('aiTestConnection');
 const aiTestStatus = document.getElementById('aiTestStatus');
 const aiThinkMode = document.getElementById('aiThinkMode');
 const aiFailover = document.getElementById('aiFailover');
+const dlxSettings = document.getElementById('dlxSettings');
+const dlxEndpoint = document.getElementById('dlxEndpoint');
+const dlxTestConnection = document.getElementById('dlxTestConnection');
+const dlxTestStatus = document.getElementById('dlxTestStatus');
 const clearSongCache = document.getElementById('clearSongCache');
 const clearAllCache = document.getElementById('clearAllCache');
 const clearStorage = document.getElementById('clearStorage');
@@ -94,8 +98,8 @@ chrome.storage.local.get(['translateButton'], (result) => {
     }
 });
 
-// Load AI provider settings
-chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode', 'aiFailover'], (result) => {
+// Load translation provider settings
+chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode', 'aiFailover', 'dlxEndpoint'], (result) => {
     if (result.translationProvider) {
         translationProvider.value = result.translationProvider;
     }
@@ -113,8 +117,18 @@ chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiMo
     }
     // Failover (instant Google translation while AI loads) is on by default.
     aiFailover.checked = result.aiFailover !== undefined ? result.aiFailover : true;
-    aiSettings.style.display = translationProvider.value === 'customAI' ? 'block' : 'none';
+    if (result.dlxEndpoint) {
+        dlxEndpoint.value = result.dlxEndpoint;
+    }
+    updateProviderSettingsVisibility();
 });
+
+// Show the settings panel for the selected provider, hide the others.
+function updateProviderSettingsVisibility() {
+    const provider = translationProvider.value;
+    aiSettings.style.display = provider === 'customAI' ? 'block' : 'none';
+    dlxSettings.style.display = provider === 'dlx' ? 'block' : 'none';
+}
 
 function sendToSpotifyTabs(message) {
     chrome.tabs.query({ url: "https://open.spotify.com/*" }, tabs => {
@@ -145,9 +159,45 @@ applyLanguageButton.addEventListener('click', async () => {
 
 translationProvider.addEventListener('change', async () => {
     const provider = translationProvider.value;
-    aiSettings.style.display = provider === 'customAI' ? 'block' : 'none';
+    updateProviderSettingsVisibility();
     await chrome.storage.local.set({translationProvider: provider});
     sendToSpotifyTabs({ updateTranslationProvider: provider });
+});
+
+async function saveAndPropagateDlxSettings() {
+    const endpoint = dlxEndpoint.value.trim();
+    if (endpoint) await ensureHostPermission(endpoint);
+    await chrome.storage.local.set({dlxEndpoint: endpoint});
+    sendToSpotifyTabs({ updateDlxSettings: { endpoint } });
+}
+
+dlxEndpoint.addEventListener('change', saveAndPropagateDlxSettings);
+
+dlxTestConnection.addEventListener('click', async () => {
+    const endpoint = dlxEndpoint.value.trim();
+    if (endpoint) {
+        const granted = await ensureHostPermission(endpoint);
+        if (!granted) {
+            dlxTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ' (access to the endpoint was not granted)';
+            dlxTestStatus.className = 'error';
+            return;
+        }
+    }
+    dlxTestStatus.textContent = chrome.i18n.getMessage('aiTestInProgress') || 'Testing...';
+    dlxTestStatus.className = 'loading';
+    try {
+        const response = await chrome.runtime.sendMessage({ type: 'TEST_DLX', endpoint });
+        if (response?.ok) {
+            dlxTestStatus.textContent = chrome.i18n.getMessage('aiTestSuccess') || 'Connection successful!';
+            dlxTestStatus.className = 'success';
+        } else {
+            dlxTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ` (${response?.error || 'unknown error'})`;
+            dlxTestStatus.className = 'error';
+        }
+    } catch (e) {
+        dlxTestStatus.textContent = (chrome.i18n.getMessage('aiTestFail') || 'Connection failed.') + ` (${e.message})`;
+        dlxTestStatus.className = 'error';
+    }
 });
 
 function endpointOrigin(endpoint) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -174,9 +174,11 @@ translationProvider.addEventListener('change', async () => {
 
 async function saveAndPropagateDlxSettings() {
     const endpoint = dlxEndpoint.value.trim();
-    if (endpoint) await ensureHostPermission(endpoint);
-    await chrome.storage.local.set({dlxEndpoint: endpoint});
-    sendToSpotifyTabs({ updateDlxSettings: { endpoint } });
+    // Dispatch the save first (the permission prompt can close the popup), then
+    // request permission before any await (user-gesture requirement).
+    chrome.storage.local.set({dlxEndpoint: endpoint}).catch(() => {});
+    const granted = !endpoint || await ensureHostPermission(endpoint);
+    if (granted) sendToSpotifyTabs({ updateDlxSettings: { endpoint } });
 }
 
 dlxEndpoint.addEventListener('change', saveAndPropagateDlxSettings);
@@ -214,6 +216,7 @@ dlxTestConnection.addEventListener('click', async () => {
         const response = await chrome.runtime.sendMessage({ type: 'TEST_PROVIDER', provider: 'dlx', endpoint });
         if (response?.ok) {
             setTestStatus(dlxTestStatus, 'success');
+            sendToSpotifyTabs({ updateDlxSettings: { endpoint } });
         } else {
             setTestStatus(dlxTestStatus, 'error', response?.error || 'unknown error');
         }
@@ -248,9 +251,11 @@ async function saveAndPropagateAiSettings() {
     const endpoint = aiEndpoint.value.trim();
     const apiKey = aiApiKey.value.trim();
     const model = aiModel.value.trim();
-    if (endpoint) await ensureHostPermission(endpoint);
-    await chrome.storage.local.set({aiEndpoint: endpoint, aiApiKey: apiKey, aiModel: model});
-    sendToSpotifyTabs({ updateAiSettings: { endpoint, apiKey, model } });
+    // Dispatch the save first (the permission prompt can close the popup), then
+    // request permission before any await (user-gesture requirement).
+    chrome.storage.local.set({aiEndpoint: endpoint, aiApiKey: apiKey, aiModel: model}).catch(() => {});
+    const granted = !endpoint || await ensureHostPermission(endpoint);
+    if (granted) sendToSpotifyTabs({ updateAiSettings: { endpoint, apiKey, model } });
 }
 
 aiEndpoint.addEventListener('change', saveAndPropagateAiSettings);
@@ -364,6 +369,7 @@ aiTestConnection.addEventListener('click', async () => {
                 const data = await response.json();
                 if (data.choices || data.id || data.object) {
                     setTestStatus(aiTestStatus, 'success');
+                    sendToSpotifyTabs({ updateAiSettings: { endpoint, apiKey, model } });
                 } else {
                     setTestStatus(aiTestStatus, 'error', 'unexpected response format');
                 }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -22,6 +22,7 @@ const dlxSettings = document.getElementById('dlxSettings');
 const dlxEndpoint = document.getElementById('dlxEndpoint');
 const dlxTestConnection = document.getElementById('dlxTestConnection');
 const dlxTestStatus = document.getElementById('dlxTestStatus');
+const dlxTranslationMode = document.getElementById('dlxTranslationMode');
 const clearSongCache = document.getElementById('clearSongCache');
 const clearAllCache = document.getElementById('clearAllCache');
 const clearStorage = document.getElementById('clearStorage');
@@ -99,7 +100,7 @@ chrome.storage.local.get(['translateButton'], (result) => {
 });
 
 // Load translation provider settings
-chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode', 'aiFailover', 'dlxEndpoint'], (result) => {
+chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode', 'aiFailover', 'dlxEndpoint', 'dlxTranslationMode'], (result) => {
     if (result.translationProvider) {
         translationProvider.value = result.translationProvider;
     }
@@ -120,6 +121,8 @@ chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiMo
     if (result.dlxEndpoint) {
         dlxEndpoint.value = result.dlxEndpoint;
     }
+    // Batch is the default: fewer requests, kinder to public DLX instances.
+    dlxTranslationMode.value = result.dlxTranslationMode || 'batch';
     updateProviderSettingsVisibility();
 });
 
@@ -172,6 +175,12 @@ async function saveAndPropagateDlxSettings() {
 }
 
 dlxEndpoint.addEventListener('change', saveAndPropagateDlxSettings);
+
+dlxTranslationMode.addEventListener('change', async () => {
+    const mode = dlxTranslationMode.value;
+    await chrome.storage.local.set({dlxTranslationMode: mode});
+    sendToSpotifyTabs({ updateDlxTranslationMode: mode });
+});
 
 dlxTestConnection.addEventListener('click', async () => {
     const endpoint = dlxEndpoint.value.trim();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -28,8 +28,7 @@ const clearAllCache = document.getElementById('clearAllCache');
 const clearStorage = document.getElementById('clearStorage');
 
 $(document).ready(function() {
-    // Render the dropdown inside the .optionDiv so the (nested) select2 CSS
-    // overrides apply — by default select2 appends it to <body>, out of scope.
+    // Render the dropdown inside .optionDiv so the nested select2 CSS overrides apply.
     $('#languageSelector').select2({
         dropdownParent: $('#languageSelector').parent()
     });
@@ -44,8 +43,8 @@ $(document).ready(function(){
 
  });
 
-// Default the dropdown to the browser language (Chromium + Firefox) when nothing
-// is stored yet, falling back to English. Mirrors getBrowserLanguage() in main.js.
+// Default the dropdown to the browser language when nothing is stored.
+// Mirrors getBrowserLanguage() in main.js.
 function getBrowserLanguage() {
     const candidates = [];
     if (Array.isArray(navigator.languages)) candidates.push(...navigator.languages);
@@ -126,9 +125,8 @@ chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'aiApiKey', 'aiMo
     updateProviderSettingsVisibility();
 });
 
-// Show the settings panel for the selected provider, hide the others.
-// Panels come from the registry (scripts/providers.js), so a new provider
-// only needs a panelId there plus its markup in popup.html.
+// Show the settings panel for the selected provider, hide the others
+// (panels come from the registry).
 function updateProviderSettingsVisibility() {
     const provider = translationProvider.value;
     for (const [id, spec] of Object.entries(TRANSLATION_PROVIDERS)) {
@@ -233,10 +231,8 @@ function endpointOrigin(endpoint) {
     }
 }
 
-// Request access to the endpoint's origin. It's declared as an optional
-// permission, so we ask for it at runtime from a user gesture instead of
-// requesting blanket access up front. request() resolves true without a
-// prompt if already granted.
+// Request access to the endpoint's origin (an optional permission asked for at
+// runtime). Resolves true without a prompt if already granted.
 async function ensureHostPermission(endpoint) {
     const pattern = endpointOrigin(endpoint);
     if (!pattern) return false;
@@ -321,8 +317,7 @@ clearAllCache.addEventListener('click', () => {
     confirmAction(clearAllCache, () => sendToSpotifyTabs({ clearCache: 'all' }));
 });
 
-// Debug: wipe all saved settings (chrome.storage), resetting the extension to
-// defaults, then reload the popup so the controls reflect the cleared state.
+// Debug: wipe all saved settings and reload the popup.
 clearStorage.addEventListener('click', () => {
     confirmAction(clearStorage, async () => {
         try { await chrome.storage.local.clear(); } catch {}

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -17,6 +17,81 @@ const ENDPOINTS = [
     }),
 ];
 
+// No default endpoint is bundled — the user must configure a DLX-compatible
+// endpoint themselves via the popup's "DLX Endpoint URL" field. This keeps
+// the choice of which server receives lyrics text an explicit, conscious one.
+// Leaving source_lang empty triggers auto-detection.
+
+// DLX expects uppercase ISO-639-1 codes (EN, ID, ZH, ...). Regional variants
+// use a hyphen + uppercase region (EN-US, PT-BR). DLX also accepts a few
+// 3-letter codes (BHO, CEB, CKB, GOM, KMR, YUE, ...) and language aliases that do
+// NOT follow the simple "uppercase the base code" rule used by the fallback.
+//
+// Only map entries that differ from the fallback to avoid noise. See the full
+// list of supported DLX languages in dlx-lang.md.
+const DLX_LANG_MAP = {
+    // Regional/variant codes where DLX diverges from the simple fallback.
+    'zh-cn': 'ZH',
+    'zh-tw': 'ZH',
+    'pt': 'PT',
+    'pt-br': 'PT-BR',
+    'pt-pt': 'PT-PT',
+    'en': 'EN',
+    'en-us': 'EN-US',
+    'en-gb': 'EN-GB',
+    // Aliases — these selector codes map to a DIFFERENT DLX code than the
+    // naive uppercased base code would produce.
+    'fil': 'TL',   // Filipino  -> DLX's Tagalog (TL), not "FIL"
+    'no': 'NB',    // Norwegian -> DLX's Norwegian Bokmål (NB), not "NO"
+    'ku': 'KMR',   // Kurdish   -> DLX's Kurmanji (KMR), not "KU"
+    // 3-letter codes supported by DLX. The fallback would actually produce
+    // these correctly, but listing them here guards against case/quoting issues
+    // and documents which 3-letter selector values are DLX-compatible.
+    'bho': 'BHO',
+    'ceb': 'CEB',
+    'ckb': 'CKB',
+    'gom': 'GOM',
+    'ig': 'IG',
+    'mai': 'MAI',
+    'pag': 'PAG',
+    'pam': 'PAM',
+    'scn': 'SCN',
+    'yi': 'YI',
+};
+
+function dlxLangCode(lang) {
+    if (!lang || lang === 'auto') return '';
+    const lower = lang.toLowerCase();
+    if (DLX_LANG_MAP[lower]) return DLX_LANG_MAP[lower];
+    // Base code uppercased (e.g. "id" -> "ID", "fr" -> "FR")
+    return lower.split('-')[0].toUpperCase();
+}
+
+async function translateWithDlx(text, sourceLanguage, destinationLanguage) {
+    const { dlxEndpoint } = await chrome.storage.local.get(['dlxEndpoint']);
+    const endpoint = (dlxEndpoint || '').trim();
+    if (!endpoint) throw new Error('No DLX endpoint configured. Set one in the extension settings.');
+    const url = endpoint.replace(/\/+$/, '');
+
+    const body = { text, target_lang: dlxLangCode(destinationLanguage) };
+    const src = dlxLangCode(sourceLanguage);
+    if (src) body.source_lang = src;
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error(`DLX HTTP ${res.status} ${res.statusText}`);
+    const data = await res.json();
+    // DLX responses: { code: 200, data: "..." } or { translations: [...] }
+    if (data && typeof data.data === 'string') return data.data;
+    if (Array.isArray(data?.translations) && data.translations[0]?.text != null) {
+        return data.translations[0].text;
+    }
+    throw new Error(`DLX unexpected response: ${JSON.stringify(data).slice(0, 200)}`);
+}
+
 const GOOGLE_LANG_MAP = {
     'zh': 'zh-CN',
     'iw': 'he',
@@ -62,6 +137,44 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
             }
             console.error('Translatify: all endpoints failed', { sl, tl, text: msg.text, failures });
             sendResponse({ error: `All endpoints failed (sl=${sl}, tl=${tl}): ${failures.join('; ')}` });
+        })();
+        return true;
+    }
+
+    if (msg.type === 'TRANSLATE_DLX') {
+        (async () => {
+            try {
+                const result = await translateWithDlx(msg.text, msg.sourceLanguage, msg.destinationLanguage);
+                if (result) return sendResponse({ result });
+                sendResponse({ error: 'DLX returned an empty result' });
+            } catch (e) {
+                console.error('Translatify: DLX translation failed', { text: msg.text, error: e.message });
+                sendResponse({ error: `DLX translation failed: ${e.message}` });
+            }
+        })();
+        return true;
+    }
+
+    if (msg.type === 'TEST_DLX') {
+        (async () => {
+            try {
+                const endpoint = (msg.endpoint || '').trim();
+                if (!endpoint) return sendResponse({ error: 'No DLX endpoint configured.' });
+                const url = endpoint.replace(/\/+$/, '');
+                const res = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ text: 'Hello', target_lang: 'ID' })
+                });
+                if (!res.ok) return sendResponse({ error: `HTTP ${res.status} ${res.statusText}` });
+                const data = await res.json().catch(() => null);
+                if (data && typeof data.data === 'string') {
+                    return sendResponse({ ok: true });
+                }
+                sendResponse({ error: 'Endpoint did not return a DLX-style {data} field' });
+            } catch (e) {
+                sendResponse({ error: e.message });
+            }
         })();
         return true;
     }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -69,8 +69,8 @@ function dlxLangCode(lang) {
 
 // Extract the translated string from a DLX response. Two shapes exist in the
 // wild: { code: 200, data: "..." } and { translations: [{ text: "..." }] }.
-// Returns null when neither is present. Shared by translateWithDlx and
-// TEST_DLX so an endpoint that translates also passes "Test Connection".
+// Returns null when neither is present. Shared by translateWithDlx and the
+// connection test so an endpoint that translates also passes "Test Connection".
 function parseDlxResponse(data) {
     if (data && typeof data.data === 'string') return data.data;
     if (Array.isArray(data?.translations) && data.translations[0]?.text != null) {
@@ -121,188 +121,190 @@ function normalizeLang(lang) {
     return GOOGLE_LANG_MAP[base] || base;
 }
 
+// Try each Google endpoint in order; return the first non-empty result.
+async function translateWithGoogle(text, sourceLanguage, destinationLanguage) {
+    const sl = normalizeLang(sourceLanguage);
+    const tl = normalizeLang(destinationLanguage);
+    const failures = [];
+    for (const endpoint of ENDPOINTS) {
+        try {
+            const { url, parse } = endpoint(text, sl, tl);
+            const res = await fetch(url);
+            if (!res.ok) {
+                failures.push(`${res.status} ${res.statusText}`);
+                continue;
+            }
+            const data = await res.json();
+            const result = parse(data);
+            if (result) return result;
+            failures.push('empty result');
+        } catch (e) {
+            failures.push(e.message);
+        }
+    }
+    throw new Error(`All endpoints failed (sl=${sl}, tl=${tl}): ${failures.join('; ')}`);
+}
+
+// Batch-translate lyrics with the user's OpenAI-compatible endpoint. Returns
+// one translated string per input line, in order; throws with a reason
+// otherwise. Settings are read here instead of passed from the content script.
+async function translateWithAI({ lines, songTitle, artistName, destinationLanguage }) {
+    const { aiEndpoint: endpoint, aiApiKey: apiKey, aiModel: model, aiThinkMode: thinkMode } =
+        await chrome.storage.local.get(['aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode']);
+    if (!endpoint || !apiKey) {
+        throw new Error('AI endpoint or API key not configured');
+    }
+
+    const baseUrl = endpoint.replace(/\/+$/, '');
+    const langName = new Intl.DisplayNames(['en'], { type: 'language' });
+    const tlName = langName.of(destinationLanguage) || destinationLanguage;
+
+    const systemPrompt = [
+        'You are a skilled literary and song lyric translator.',
+        'Translate the following song lyrics into ' + tlName + '.',
+        songTitle ? 'Song title: "' + songTitle + '"' : '',
+        artistName ? 'Artist: ' + artistName : '',
+        '',
+        'Guidelines:',
+        '- Preserve the poetic, emotional, and rhythmic qualities of the original lyrics.',
+        '- Maintain the tone, mood, and style appropriate to the song genre.',
+        '- Adapt idioms, metaphors, and cultural references naturally into the target language.',
+        '- Keep line breaks and verse structure — each input line must have exactly one output line.',
+        '- Do NOT add explanations, notes, or commentary.',
+        '- Return a JSON object with exactly one field "translations" that is an array of strings.',
+        '- The array must contain exactly one translated string per input line, in the same order.',
+        '- Example: {"translations": ["translated line 1", "translated line 2", ...]}',
+        '',
+        'Input lyrics (one string per line, translate each independently while maintaining overall coherence):'
+    ].filter(Boolean).join('\n');
+
+    const body = {
+        model: model || 'gpt-4o-mini',
+        messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: JSON.stringify(lines) }
+        ],
+        temperature: 0.7,
+        response_format: { type: 'json_object' }
+    };
+
+    if (thinkMode === false) {
+        body.reasoning_effort = 'none';
+        body.thinking = { type: 'disabled' };
+    }
+
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`API error ${response.status}: ${errorText}`);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+        const preview = await response.text().catch(() => '');
+        throw new Error(`Endpoint returned ${contentType || 'unknown content'} instead of JSON. Check that the endpoint URL includes the full API path (e.g. https://api.openai.com/v1 for OpenAI). Preview: ${preview.slice(0, 200)}`);
+    }
+
+    let data;
+    try {
+        data = await response.json();
+    } catch (e) {
+        throw new Error(`Failed to parse API response as JSON. Check your endpoint URL — it should include the full path (e.g. https://api.openai.com/v1 for OpenAI). Error: ${e.message}`);
+    }
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+        throw new Error('Empty response from AI');
+    }
+
+    const parsed = JSON.parse(content);
+    const translations = Array.isArray(parsed) ? parsed
+        : parsed.translations || parsed.lines || parsed.results || [];
+
+    if (translations.length !== lines.length) {
+        throw new Error(`AI returned ${translations.length} translations for ${lines.length} lines (line count mismatch)`);
+    }
+
+    return translations;
+}
+
+// Translation providers, keyed by the id the content script sends in the
+// TRANSLATE message. Each takes the message and resolves to exactly one
+// translated string per input line. Adding a provider means adding an entry
+// here (and its popup settings) — not a new message type.
+const TRANSLATE_PROVIDERS = {
+    google: (msg) => Promise.all(msg.lines.map(line => translateWithGoogle(line, msg.sourceLanguage, msg.destinationLanguage))),
+    dlx: async (msg) => {
+        // A single line keeps exact per-line semantics (no newline splitting).
+        if (msg.lines.length === 1) {
+            return [await translateWithDlx(msg.lines[0], msg.sourceLanguage, msg.destinationLanguage)];
+        }
+        // DLX preserves newlines: the whole sheet goes out as one request and
+        // comes back as one string to split up again.
+        const result = await translateWithDlx(msg.lines.join('\n'), msg.sourceLanguage, msg.destinationLanguage);
+        const translations = (result || '').split('\n');
+        if (translations.length !== msg.lines.length) {
+            // The endpoint merged or dropped lines; the caller falls back to
+            // per-line requests rather than misaligning lyrics.
+            throw new Error(`DLX batch line count mismatch (got ${translations.length} for ${msg.lines.length} lines)`);
+        }
+        return translations;
+    },
+    customAI: (msg) => translateWithAI(msg),
+};
+
+// Connection tests, same keying. Resolve on success, throw with a reason on
+// failure. Providers without an entry have nothing testable from here.
+const TEST_PROVIDERS = {
+    dlx: async (msg) => {
+        const endpoint = (msg.endpoint || '').trim();
+        if (!endpoint) throw new Error('No DLX endpoint configured.');
+        const url = endpoint.replace(/\/+$/, '');
+        const res = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: 'Hello', target_lang: 'ID' })
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+        const data = await res.json().catch(() => null);
+        if (parseDlxResponse(data) == null) {
+            throw new Error('Endpoint did not return a DLX-style response ({data} or {translations})');
+        }
+    },
+};
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.type === 'TRANSLATE') {
         (async () => {
-            const sl = normalizeLang(msg.sourceLanguage);
-            const tl = normalizeLang(msg.destinationLanguage);
-            const failures = [];
-            for (const endpoint of ENDPOINTS) {
-                try {
-                    const { url, parse } = endpoint(msg.text, sl, tl);
-                    const res = await fetch(url);
-                    if (!res.ok) {
-                        failures.push(`${res.status} ${res.statusText}`);
-                        continue;
-                    }
-                    const data = await res.json();
-                    const result = parse(data);
-                    if (result) return sendResponse({ result });
-                    failures.push('empty result');
-                } catch (e) {
-                    failures.push(e.message);
-                    continue;
-                }
-            }
-            console.error('Translatify: all endpoints failed', { sl, tl, text: msg.text, failures });
-            sendResponse({ error: `All endpoints failed (sl=${sl}, tl=${tl}): ${failures.join('; ')}` });
-        })();
-        return true;
-    }
-
-    if (msg.type === 'TRANSLATE_DLX') {
-        (async () => {
             try {
-                const result = await translateWithDlx(msg.text, msg.sourceLanguage, msg.destinationLanguage);
-                if (result) return sendResponse({ result });
-                sendResponse({ error: 'DLX returned an empty result' });
+                const provider = TRANSLATE_PROVIDERS[msg.provider];
+                if (!provider) return sendResponse({ error: `Unknown translation provider: ${msg.provider}` });
+                if (!Array.isArray(msg.lines) || msg.lines.length === 0) {
+                    return sendResponse({ error: 'No lines to translate' });
+                }
+                sendResponse({ translations: await provider(msg) });
             } catch (e) {
-                console.error('Translatify: DLX translation failed', { text: msg.text, error: e.message });
-                sendResponse({ error: `DLX translation failed: ${e.message}` });
+                console.error(`Translatify: ${msg.provider} translation failed`, e.message);
+                sendResponse({ error: `${msg.provider} translation failed: ${e.message}` });
             }
         })();
         return true;
     }
 
-    if (msg.type === 'TRANSLATE_DLX_BATCH') {
+    if (msg.type === 'TEST_PROVIDER') {
         (async () => {
             try {
-                const lines = Array.isArray(msg.lines) ? msg.lines : [];
-                if (lines.length === 0) return sendResponse({ error: 'DLX batch: no lines given' });
-                // DLX preserves newlines, so the whole sheet goes out as one
-                // request and comes back as one string to split up again.
-                const result = await translateWithDlx(lines.join('\n'), msg.sourceLanguage, msg.destinationLanguage);
-                const translations = (result || '').split('\n');
-                if (translations.length !== lines.length) {
-                    // The endpoint merged or dropped lines; the caller falls
-                    // back to per-line requests rather than misaligning lyrics.
-                    return sendResponse({ error: `DLX batch line count mismatch (got ${translations.length} for ${lines.length} lines)` });
-                }
-                sendResponse({ translations });
-            } catch (e) {
-                console.error('Translatify: DLX batch translation failed', e.message);
-                sendResponse({ error: `DLX batch translation failed: ${e.message}` });
-            }
-        })();
-        return true;
-    }
-
-    if (msg.type === 'TEST_DLX') {
-        (async () => {
-            try {
-                const endpoint = (msg.endpoint || '').trim();
-                if (!endpoint) return sendResponse({ error: 'No DLX endpoint configured.' });
-                const url = endpoint.replace(/\/+$/, '');
-                const res = await fetch(url, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ text: 'Hello', target_lang: 'ID' })
-                });
-                if (!res.ok) return sendResponse({ error: `HTTP ${res.status} ${res.statusText}` });
-                const data = await res.json().catch(() => null);
-                if (parseDlxResponse(data) != null) {
-                    return sendResponse({ ok: true });
-                }
-                sendResponse({ error: 'Endpoint did not return a DLX-style response ({data} or {translations})' });
-            } catch (e) {
-                sendResponse({ error: e.message });
-            }
-        })();
-        return true;
-    }
-
-    if (msg.type === 'TRANSLATE_BATCH') {
-        (async () => {
-            try {
-                const { lines, songTitle, artistName, destinationLanguage } = msg;
-
-                // Read settings here instead of passing them from the content script.
-                const { aiEndpoint: endpoint, aiApiKey: apiKey, aiModel: model, aiThinkMode: thinkMode } =
-                    await chrome.storage.local.get(['aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode']);
-                if (!endpoint || !apiKey) {
-                    return sendResponse({ error: 'AI endpoint or API key not configured' });
-                }
-
-                const baseUrl = endpoint.replace(/\/+$/, '');
-                const langName = new Intl.DisplayNames(['en'], { type: 'language' });
-                const tlName = langName.of(destinationLanguage) || destinationLanguage;
-
-                const systemPrompt = [
-                    'You are a skilled literary and song lyric translator.',
-                    'Translate the following song lyrics into ' + tlName + '.',
-                    songTitle ? 'Song title: "' + songTitle + '"' : '',
-                    artistName ? 'Artist: ' + artistName : '',
-                    '',
-                    'Guidelines:',
-                    '- Preserve the poetic, emotional, and rhythmic qualities of the original lyrics.',
-                    '- Maintain the tone, mood, and style appropriate to the song genre.',
-                    '- Adapt idioms, metaphors, and cultural references naturally into the target language.',
-                    '- Keep line breaks and verse structure — each input line must have exactly one output line.',
-                    '- Do NOT add explanations, notes, or commentary.',
-                    '- Return a JSON object with exactly one field "translations" that is an array of strings.',
-                    '- The array must contain exactly one translated string per input line, in the same order.',
-                    '- Example: {"translations": ["translated line 1", "translated line 2", ...]}',
-                    '',
-                    'Input lyrics (one string per line, translate each independently while maintaining overall coherence):'
-                ].filter(Boolean).join('\n');
-
-                const userMessage = JSON.stringify(lines);
-
-                const body = {
-                    model: model || 'gpt-4o-mini',
-                    messages: [
-                        { role: 'system', content: systemPrompt },
-                        { role: 'user', content: userMessage }
-                    ],
-                    temperature: 0.7,
-                    response_format: { type: 'json_object' }
-                };
-
-                if (thinkMode === false) {
-                    body.reasoning_effort = 'none';
-                    body.thinking = { type: 'disabled' };
-                }
-
-                const response = await fetch(`${baseUrl}/chat/completions`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${apiKey}`
-                    },
-                    body: JSON.stringify(body)
-                });
-
-                if (!response.ok) {
-                    const errorText = await response.text();
-                    return sendResponse({ error: `API error ${response.status}: ${errorText}` });
-                }
-
-                const contentType = response.headers.get('content-type') || '';
-                if (!contentType.includes('application/json')) {
-                    const preview = await response.text().catch(() => '');
-                    return sendResponse({ error: `Endpoint returned ${contentType || 'unknown content'} instead of JSON. Check that the endpoint URL includes the full API path (e.g. https://api.openai.com/v1 for OpenAI). Preview: ${preview.slice(0, 200)}` });
-                }
-
-                let data;
-                try {
-                    data = await response.json();
-                } catch (e) {
-                    return sendResponse({ error: `Failed to parse API response as JSON. Check your endpoint URL — it should include the full path (e.g. https://api.openai.com/v1 for OpenAI). Error: ${e.message}` });
-                }
-                const content = data.choices?.[0]?.message?.content;
-                if (!content) {
-                    return sendResponse({ error: 'Empty response from AI' });
-                }
-
-                const parsed = JSON.parse(content);
-                const translations = Array.isArray(parsed) ? parsed
-                    : parsed.translations || parsed.lines || parsed.results || [];
-
-                if (translations.length !== lines.length) {
-                    return sendResponse({ error: `AI returned ${translations.length} translations for ${lines.length} lines (line count mismatch)` });
-                }
-
-                sendResponse({ translations });
+                const test = TEST_PROVIDERS[msg.provider];
+                if (!test) return sendResponse({ error: `No connection test for provider: ${msg.provider}` });
+                await test(msg);
+                sendResponse({ ok: true });
             } catch (e) {
                 sendResponse({ error: e.message });
             }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -164,6 +164,29 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         return true;
     }
 
+    if (msg.type === 'TRANSLATE_DLX_BATCH') {
+        (async () => {
+            try {
+                const lines = Array.isArray(msg.lines) ? msg.lines : [];
+                if (lines.length === 0) return sendResponse({ error: 'DLX batch: no lines given' });
+                // DLX preserves newlines, so the whole sheet goes out as one
+                // request and comes back as one string to split up again.
+                const result = await translateWithDlx(lines.join('\n'), msg.sourceLanguage, msg.destinationLanguage);
+                const translations = (result || '').split('\n');
+                if (translations.length !== lines.length) {
+                    // The endpoint merged or dropped lines; the caller falls
+                    // back to per-line requests rather than misaligning lyrics.
+                    return sendResponse({ error: `DLX batch line count mismatch (got ${translations.length} for ${lines.length} lines)` });
+                }
+                sendResponse({ translations });
+            } catch (e) {
+                console.error('Translatify: DLX batch translation failed', e.message);
+                sendResponse({ error: `DLX batch translation failed: ${e.message}` });
+            }
+        })();
+        return true;
+    }
+
     if (msg.type === 'TEST_DLX') {
         (async () => {
             try {

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -17,18 +17,11 @@ const ENDPOINTS = [
     }),
 ];
 
-// No default endpoint is bundled — the user must configure a DLX-compatible
-// endpoint themselves via the popup's "DLX Endpoint URL" field. This keeps
-// the choice of which server receives lyrics text an explicit, conscious one.
-// Leaving source_lang empty triggers auto-detection.
+// No default endpoint is bundled — the user configures a DLX endpoint in the
+// popup. Empty source_lang triggers auto-detection.
 
-// DLX expects uppercase ISO-639-1 codes (EN, ID, ZH, ...). Regional variants
-// use a hyphen + uppercase region (EN-US, PT-BR). DLX also accepts a few
-// 3-letter codes (BHO, CEB, CKB, GOM, KMR, YUE, ...) and language aliases that do
-// NOT follow the simple "uppercase the base code" rule used by the fallback.
-//
-// Only map entries that differ from the fallback to avoid noise. See the full
-// list of supported DLX languages in dlx-lang.md.
+// Maps selector codes to DLX codes. Only entries that differ from the fallback
+// (uppercased base code) are listed. See dlx-lang.md for the full list.
 const DLX_LANG_MAP = {
     // Regional/variant codes where DLX diverges from the simple fallback.
     'zh-cn': 'ZH',
@@ -39,14 +32,11 @@ const DLX_LANG_MAP = {
     'en': 'EN',
     'en-us': 'EN-US',
     'en-gb': 'EN-GB',
-    // Aliases — these selector codes map to a DIFFERENT DLX code than the
-    // naive uppercased base code would produce.
+    // Aliases that map to a different DLX code than the uppercased base.
     'fil': 'TL',   // Filipino  -> DLX's Tagalog (TL), not "FIL"
     'no': 'NB',    // Norwegian -> DLX's Norwegian Bokmål (NB), not "NO"
     'ku': 'KMR',   // Kurdish   -> DLX's Kurmanji (KMR), not "KU"
-    // 3-letter codes supported by DLX. The fallback would actually produce
-    // these correctly, but listing them here guards against case/quoting issues
-    // and documents which 3-letter selector values are DLX-compatible.
+    // 3-letter codes the fallback already handles, listed for documentation.
     'bho': 'BHO',
     'ceb': 'CEB',
     'ckb': 'CKB',
@@ -67,10 +57,8 @@ function dlxLangCode(lang) {
     return lower.split('-')[0].toUpperCase();
 }
 
-// Extract the translated string from a DLX response. Two shapes exist in the
-// wild: { code: 200, data: "..." } and { translations: [{ text: "..." }] }.
-// Returns null when neither is present. Shared by translateWithDlx and the
-// connection test so an endpoint that translates also passes "Test Connection".
+// Extract the translated string from a DLX response. Two shapes:
+// { data: "..." } and { translations: [{ text: "..." }] }; null if neither.
 function parseDlxResponse(data) {
     if (data && typeof data.data === 'string') return data.data;
     if (Array.isArray(data?.translations) && data.translations[0]?.text != null) {
@@ -146,8 +134,7 @@ async function translateWithGoogle(text, sourceLanguage, destinationLanguage) {
 }
 
 // Batch-translate lyrics with the user's OpenAI-compatible endpoint. Returns
-// one translated string per input line, in order; throws with a reason
-// otherwise. Settings are read here instead of passed from the content script.
+// one translated string per input line; throws otherwise.
 async function translateWithAI({ lines, songTitle, artistName, destinationLanguage }) {
     const { aiEndpoint: endpoint, aiApiKey: apiKey, aiModel: model, aiThinkMode: thinkMode } =
         await chrome.storage.local.get(['aiEndpoint', 'aiApiKey', 'aiModel', 'aiThinkMode']);
@@ -235,10 +222,8 @@ async function translateWithAI({ lines, songTitle, artistName, destinationLangua
     return translations;
 }
 
-// Translation providers, keyed by the id the content script sends in the
-// TRANSLATE message. Each takes the message and resolves to exactly one
-// translated string per input line. Adding a provider means adding an entry
-// here (and its popup settings) — not a new message type.
+// Translation providers, keyed by the id in the TRANSLATE message. Each
+// resolves to one translated string per input line.
 const TRANSLATE_PROVIDERS = {
     google: (msg) => Promise.all(msg.lines.map(line => translateWithGoogle(line, msg.sourceLanguage, msg.destinationLanguage))),
     dlx: async (msg) => {
@@ -246,13 +231,11 @@ const TRANSLATE_PROVIDERS = {
         if (msg.lines.length === 1) {
             return [await translateWithDlx(msg.lines[0], msg.sourceLanguage, msg.destinationLanguage)];
         }
-        // DLX preserves newlines: the whole sheet goes out as one request and
-        // comes back as one string to split up again.
+        // DLX preserves newlines: send the whole sheet as one request, split the result.
         const result = await translateWithDlx(msg.lines.join('\n'), msg.sourceLanguage, msg.destinationLanguage);
         const translations = (result || '').split('\n');
         if (translations.length !== msg.lines.length) {
-            // The endpoint merged or dropped lines; the caller falls back to
-            // per-line requests rather than misaligning lyrics.
+            // The endpoint merged or dropped lines; throw rather than misalign lyrics.
             throw new Error(`DLX batch line count mismatch (got ${translations.length} for ${msg.lines.length} lines)`);
         }
         return translations;
@@ -260,8 +243,7 @@ const TRANSLATE_PROVIDERS = {
     customAI: (msg) => translateWithAI(msg),
 };
 
-// Connection tests, same keying. Resolve on success, throw with a reason on
-// failure. Providers without an entry have nothing testable from here.
+// Connection tests, same keying. Resolve on success, throw on failure.
 const TEST_PROVIDERS = {
     dlx: async (msg) => {
         const endpoint = (msg.endpoint || '').trim();

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -67,6 +67,18 @@ function dlxLangCode(lang) {
     return lower.split('-')[0].toUpperCase();
 }
 
+// Extract the translated string from a DLX response. Two shapes exist in the
+// wild: { code: 200, data: "..." } and { translations: [{ text: "..." }] }.
+// Returns null when neither is present. Shared by translateWithDlx and
+// TEST_DLX so an endpoint that translates also passes "Test Connection".
+function parseDlxResponse(data) {
+    if (data && typeof data.data === 'string') return data.data;
+    if (Array.isArray(data?.translations) && data.translations[0]?.text != null) {
+        return data.translations[0].text;
+    }
+    return null;
+}
+
 async function translateWithDlx(text, sourceLanguage, destinationLanguage) {
     const { dlxEndpoint } = await chrome.storage.local.get(['dlxEndpoint']);
     const endpoint = (dlxEndpoint || '').trim();
@@ -84,11 +96,8 @@ async function translateWithDlx(text, sourceLanguage, destinationLanguage) {
     });
     if (!res.ok) throw new Error(`DLX HTTP ${res.status} ${res.statusText}`);
     const data = await res.json();
-    // DLX responses: { code: 200, data: "..." } or { translations: [...] }
-    if (data && typeof data.data === 'string') return data.data;
-    if (Array.isArray(data?.translations) && data.translations[0]?.text != null) {
-        return data.translations[0].text;
-    }
+    const result = parseDlxResponse(data);
+    if (result != null) return result;
     throw new Error(`DLX unexpected response: ${JSON.stringify(data).slice(0, 200)}`);
 }
 
@@ -168,10 +177,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
                 });
                 if (!res.ok) return sendResponse({ error: `HTTP ${res.status} ${res.statusText}` });
                 const data = await res.json().catch(() => null);
-                if (data && typeof data.data === 'string') {
+                if (parseDlxResponse(data) != null) {
                     return sendResponse({ ok: true });
                 }
-                sendResponse({ error: 'Endpoint did not return a DLX-style {data} field' });
+                sendResponse({ error: 'Endpoint did not return a DLX-style response ({data} or {translations})' });
             } catch (e) {
                 sendResponse({ error: e.message });
             }

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -36,6 +36,11 @@ let aiBatchPending = false;
 // the MutationObserver does not Google-translate lines that appear during the wait.
 let aiFailoverEnabled = true;
 
+// Active translation provider for the current pass. "google" uses TRANSLATE messages
+// (Google endpoints); "dlx" routes the same line-by-line path through TRANSLATE_DLX
+// (the DLX endpoint — no API key required). "customAI" is handled separately via the batch flow.
+let activeProvider = 'google';
+
 // Re-entrancy guard for translate(), set before any await.
 let translateInFlight = false;
 
@@ -99,8 +104,9 @@ async function translateText(text, sourceLanguage, destinationLanguage) {
     const requestPromise = (async () => {
         let response;
         try {
+            const messageType = activeProvider === 'dlx' ? 'TRANSLATE_DLX' : 'TRANSLATE';
             response = await chrome.runtime.sendMessage({
-                type: 'TRANSLATE',
+                type: messageType,
                 text,
                 sourceLanguage,
                 destinationLanguage
@@ -520,11 +526,17 @@ async function runTranslate() {
         // Gate on provider + endpoint; the background reads the rest and falls
         // back to Google if it isn't configured.
         const settings = await chrome.storage.local.get(['translationProvider', 'aiEndpoint']);
+        // Make the active provider visible to translateText() so per-line calls
+        // (both in the live pass and the MutationObserver) use the right endpoint.
+        activeProvider = settings.translationProvider === 'dlx' ? 'dlx' : 'google';
         // Show the loading indicator only while lyrics are actually being fetched/rendered.
         setTranslatingIndicator(true);
         let aiErrored = false;
         try {
             if (settings.translationProvider === 'customAI' && settings.aiEndpoint) {
+                // AI batch uses its own provider-aware flow; restore line-by-line
+                // defaults for the failover pre-pass so Google still works there.
+                activeProvider = 'google';
                 aiErrored = (await translateBatchWithAIAndRender(sourceLanguage, destinationLanguage)) === false;
             } else {
                 await translateLineByLineWithGoogle(sourceLanguage, destinationLanguage);

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -278,6 +278,7 @@ function scheduleDlxBatch() {
     if (dlxDebounceTimer) clearTimeout(dlxDebounceTimer);
     dlxDebounceTimer = setTimeout(async () => {
         const pending = dlxPendingMisses.splice(0);
+        console.log('Translatify: DLX fallback batch executing for', pending.length, 'lines');
         if (pending.length === 0 || !isExtensionAlive()) return;
 
         const sourceLanguage = pending[0].sourceLanguage;

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -41,13 +41,9 @@ let aiBatchPending = false;
 // the MutationObserver does not Google-translate lines that appear during the wait.
 let aiFailoverEnabled = true;
 
-// Cache keys are namespaced by provider so switching providers (google <-> dlx)
-// never serves the other provider's cached results. The provider is passed
-// explicitly through the whole call chain (no mutable module state), so a pass
-// keeps using the provider it started with even if the user switches mid-pass.
-// The AI flow deliberately uses 'google' here: its results overwrite the
-// entries the Google failover pre-pass wrote, and the MutationObserver reads
-// them back from the same namespace.
+// Provider-namespaced cache key (google, dlx, customAI) so each provider's
+// results stay separate. The provider is passed explicitly through the call
+// chain, so a pass keeps its namespace even if the user switches mid-pass.
 function lineCacheKey(provider, text, sourceLanguage, destinationLanguage) {
     return `${provider}|${text}|${sourceLanguage}|${destinationLanguage}`;
 }
@@ -321,7 +317,12 @@ function scheduleDlxBatch() {
     }, 200);
 }
 
-async function setupMutationObserver(provider, mode) {
+async function setupMutationObserver(provider, mode, readProviders) {
+    // Cache namespaces the observer reads, highest priority first. Defaults to
+    // the provider's own; the AI flow passes ['customAI', 'google'] so a
+    // re-rendered line shows the AI result, not the Google failover copy.
+    const readNamespaces = readProviders || [provider];
+
     // Use a single observer that watches the main view for any changes
     const observerKey = `mainView`;
 
@@ -351,10 +352,18 @@ async function setupMutationObserver(provider, mode) {
             const lyricsText = wrapper.firstChild?.textContent;
             if (!lyricsText) return;
 
-            const cacheKey = lineCacheKey(provider, lyricsText, sourceLanguage, destinationLanguage);
-            if (translationCache.has(cacheKey)) {
-                replaceLyric(translationCache.get(cacheKey), wrapper);
-            } else if (provider === 'dlx') {
+            // Render from cache, checking read namespaces in priority order so
+            // an AI result in 'customAI' wins over the 'google' failover copy.
+            for (const ns of readNamespaces) {
+                const key = lineCacheKey(ns, lyricsText, sourceLanguage, destinationLanguage);
+                if (translationCache.has(key)) {
+                    replaceLyric(translationCache.get(key), wrapper);
+                    focusActiveLyric();
+                    return;
+                }
+            }
+
+            if (provider === 'dlx') {
                 // Untranslatable lines (♪, pure punctuation) are marked as
                 // themselves; only real text needs a DLX request.
                 if (isUntranslatable(lyricsText)) {
@@ -545,7 +554,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
         currentWrappers.forEach(wrapper => {
             if (wrapper.classList.contains("modifedLyricsWrapper")) return;
             const text = wrapper.firstChild?.textContent || '';
-            const cacheKey = lineCacheKey('google', text, sourceLanguage, destinationLanguage);
+            const cacheKey = lineCacheKey('customAI', text, sourceLanguage, destinationLanguage);
             const cached = translationCache.get(cacheKey);
             if (cached != null) {
                 replaceLyric(cached, wrapper);
@@ -560,8 +569,9 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
 
     // Start the MutationObserver now so that lyrics appearing during the AI
     // call get Google-translated immediately.  Once the AI batch completes,
-    // all visible translations are replaced with the AI results.
-    setupMutationObserver('google');
+    // all visible translations are replaced with the AI results. It reads
+    // 'customAI' first, then 'google', so re-rendered lines prefer the AI text.
+    setupMutationObserver('google', undefined, ['customAI', 'google']);
 
     aiBatchPending = true;
 
@@ -604,11 +614,11 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     // late Google write can't clobber the AI translation in translationCache.
     await googlePass;
 
-    // Populate line-level cache from the AI batch so the MutationObserver picks
-    // up AI translations instead of falling back to Google.
+    // Cache the AI batch results under Custom AI's 'customAI' namespace; the
+    // fast path above and the render loop below read them back.
     for (let i = 0; i < lines.length; i++) {
         if (translations[i] != null && lines[i]) {
-            translationCache.set(lineCacheKey('google', lines[i], sourceLanguage, destinationLanguage), translations[i]);
+            translationCache.set(lineCacheKey('customAI', lines[i], sourceLanguage, destinationLanguage), translations[i]);
         }
     }
 
@@ -620,7 +630,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     const currentWrappers = Array.from(document.querySelectorAll(lyricLine));
     currentWrappers.forEach(wrapper => {
         const text = wrapper.firstChild?.textContent || '';
-        const cacheKey = lineCacheKey('google', text, sourceLanguage, destinationLanguage);
+        const cacheKey = lineCacheKey('customAI', text, sourceLanguage, destinationLanguage);
         const aiTranslation = translationCache.get(cacheKey);
         if (aiTranslation == null) return;
 
@@ -635,7 +645,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     });
 
     focusActiveLyric();
-    setupMutationObserver('google');
+    setupMutationObserver('google', undefined, ['customAI', 'google']);
 }
 
 // MAIN TRANSLATION FUNCTION

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -49,6 +49,11 @@ function lineCacheKey(text, sourceLanguage, destinationLanguage) {
     return `${activeProvider}|${text}|${sourceLanguage}|${destinationLanguage}`;
 }
 
+// Whether DLX translates the whole sheet in one request ('batch', the default)
+// or one request per line ('perline'). User choice, stored as dlxTranslationMode;
+// refreshed on every pass in runTranslate().
+let dlxBatchEnabled = true;
+
 // Re-entrancy guard for translate(), set before any await.
 let translateInFlight = false;
 
@@ -150,15 +155,6 @@ function getSongInfo() {
         songTitle: titleEl?.textContent?.trim() || '',
         artistName: artistEl?.textContent?.trim() || ''
     };
-}
-
-async function translateLineByLine(lines, sourceLanguage, destinationLanguage) {
-    const results = [];
-    for (const text of lines) {
-        const translated = await translateText(text, sourceLanguage, destinationLanguage);
-        results.push(translated != null ? translated : text);
-    }
-    return results;
 }
 
 async function translateBatchWithAI(lines, sourceLanguage, destinationLanguage) {
@@ -388,6 +384,71 @@ async function translateLineByLineWithGoogle(sourceLanguage, destinationLanguage
     setupMutationObserver();
 }
 
+// Translate the whole lyric sheet in one DLX request (DLX preserves newlines),
+// then render every wrapper from the per-line cache. Much kinder to public DLX
+// instances than one POST per line. Falls back to the per-line flow when the
+// batch fails (network error, endpoint quirk, line-count mismatch).
+async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
+    const lyricsWrapperList = document.querySelectorAll(lyricLine);
+
+    if (lyricsWrapperList.length === 0) {
+        console.log("Translatify: lyrics not found, retrying..");
+        return setTimeout(translate, 100);
+    }
+
+    // Unique lines that actually need a request: translatable and not cached.
+    const uncached = [...new Set(
+        Array.from(lyricsWrapperList)
+            .map(w => w.firstChild?.textContent)
+            .filter(text => text && !isUntranslatable(text) &&
+                !translationCache.has(lineCacheKey(text, sourceLanguage, destinationLanguage)))
+    )];
+
+    if (uncached.length > 0) {
+        if (!isExtensionAlive()) return;
+        let response;
+        try {
+            response = await chrome.runtime.sendMessage({
+                type: 'TRANSLATE_DLX_BATCH',
+                lines: uncached,
+                sourceLanguage,
+                destinationLanguage
+            });
+        } catch {
+            response = null;
+        }
+
+        if (!response || response.error || !Array.isArray(response.translations)) {
+            if (response?.error) console.error('Translatify: DLX batch failed, falling back to per-line:', response.error);
+            return translateLineByLineWithGoogle(sourceLanguage, destinationLanguage);
+        }
+
+        uncached.forEach((text, i) => {
+            if (response.translations[i] != null) {
+                translationCache.set(lineCacheKey(text, sourceLanguage, destinationLanguage), response.translations[i]);
+            }
+        });
+    }
+
+    // Render every visible wrapper from the cache. The DOM may have changed
+    // while the request was in flight, so re-query and match by text.
+    // Untranslatable lines (pure punctuation, "♪") are "translated" to
+    // themselves like the per-line flow does, so they get marked and don't
+    // keep the observer's catch-up pass firing forever.
+    document.querySelectorAll(lyricLine).forEach(wrapper => {
+        if (wrapper.classList.contains("modifedLyricsWrapper")) return;
+        const text = wrapper.firstChild?.textContent;
+        if (!text) return;
+        const translated = isUntranslatable(text)
+            ? text
+            : translationCache.get(lineCacheKey(text, sourceLanguage, destinationLanguage));
+        if (translated != null) replaceLyric(translated, wrapper);
+    });
+
+    focusActiveLyric();
+    setupMutationObserver();
+}
+
 // Batch translate all lyrics with AI, then render them
 async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage) {
     const lyricsWrapperList = document.querySelectorAll(lyricLine);
@@ -548,10 +609,11 @@ async function runTranslate() {
         // they're missing: TRANSLATE_DLX has no fallback of its own in the
         // background, so routing there without an endpoint would just error on
         // every line and leave the lyrics untranslated.
-        const settings = await chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'dlxEndpoint']);
+        const settings = await chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'dlxEndpoint', 'dlxTranslationMode']);
         // Make the active provider visible to translateText() so per-line calls
         // (both in the live pass and the MutationObserver) use the right endpoint.
         activeProvider = (settings.translationProvider === 'dlx' && settings.dlxEndpoint) ? 'dlx' : 'google';
+        dlxBatchEnabled = settings.dlxTranslationMode !== 'perline';
         // Show the loading indicator only while lyrics are actually being fetched/rendered.
         setTranslatingIndicator(true);
         let aiErrored = false;
@@ -561,6 +623,8 @@ async function runTranslate() {
                 // defaults for the failover pre-pass so Google still works there.
                 activeProvider = 'google';
                 aiErrored = (await translateBatchWithAIAndRender(sourceLanguage, destinationLanguage)) === false;
+            } else if (activeProvider === 'dlx' && dlxBatchEnabled) {
+                await translateBatchWithDlx(sourceLanguage, destinationLanguage);
             } else {
                 await translateLineByLineWithGoogle(sourceLanguage, destinationLanguage);
             }

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -22,6 +22,11 @@ const inFlightTranslations = new Map();
 // Active mutation observers
 const mutationObservers = new Map();
 
+// DLX batch fallback: lines that the MutationObserver found uncached are queued
+// here and batch-translated after a short debounce instead of per-line.
+const dlxPendingMisses = [];
+let dlxDebounceTimer = null;
+
 // To modify if spotify decides to change variable names
 const lyricLine = "div[data-testid='lyrics-line']";
 
@@ -228,6 +233,9 @@ function disconnectAllObservers() {
         console.log('Disconnected observer for:', key);
     });
     mutationObservers.clear();
+    // Flush pending DLX batch fallback
+    if (dlxDebounceTimer) { clearTimeout(dlxDebounceTimer); dlxDebounceTimer = null; }
+    dlxPendingMisses.length = 0;
 }
 
 function restoreLyrics() {
@@ -263,6 +271,48 @@ function restoreLyrics() {
 // goes through restoreLyrics() -> disconnectAllObservers(), so the next pass
 // recreates the observer with the then-current provider — in-flight callbacks
 // can never mix endpoints or cache namespaces.
+
+// Batch-translate queued DLX cache-miss lines after a short debounce so the
+// observer never fires per-line requests (which would give inconsistent results).
+function scheduleDlxBatch() {
+    if (dlxDebounceTimer) clearTimeout(dlxDebounceTimer);
+    dlxDebounceTimer = setTimeout(async () => {
+        const pending = dlxPendingMisses.splice(0);
+        if (pending.length === 0 || !isExtensionAlive()) return;
+
+        const sourceLanguage = pending[0].sourceLanguage;
+        const destinationLanguage = pending[0].destinationLanguage;
+        const uniqueLines = [...new Set(pending.map(p => p.lyricsText))];
+
+        let response;
+        try {
+            response = await chrome.runtime.sendMessage({
+                type: 'TRANSLATE',
+                provider: 'dlx',
+                lines: uniqueLines,
+                sourceLanguage,
+                destinationLanguage
+            });
+        } catch {
+            return;
+        }
+
+        if (!response || response.error || !Array.isArray(response.translations)) return;
+
+        uniqueLines.forEach((text, i) => {
+            if (response.translations[i] != null) {
+                translationCache.set(lineCacheKey('dlx', text, sourceLanguage, destinationLanguage), response.translations[i]);
+            }
+        });
+
+        pending.forEach(({ wrapper, lyricsText }) => {
+            if (wrapper.classList.contains("modifedLyricsWrapper")) return;
+            const translated = translationCache.get(lineCacheKey('dlx', lyricsText, sourceLanguage, destinationLanguage));
+            if (translated != null) replaceLyric(translated, wrapper);
+        });
+    }, 200);
+}
+
 async function setupMutationObserver(provider) {
     // Use a single observer that watches the main view for any changes
     const observerKey = `mainView`;
@@ -296,7 +346,10 @@ async function setupMutationObserver(provider) {
             const cacheKey = lineCacheKey(provider, lyricsText, sourceLanguage, destinationLanguage);
             if (translationCache.has(cacheKey)) {
                 replaceLyric(translationCache.get(cacheKey), wrapper);
-            } else if (provider !== 'dlx' && !(aiBatchPending && !aiFailoverEnabled)) {
+            } else if (provider === 'dlx') {
+                dlxPendingMisses.push({ wrapper, lyricsText, sourceLanguage, destinationLanguage });
+                scheduleDlxBatch();
+            } else if (!(aiBatchPending && !aiFailoverEnabled)) {
                 translateAndUpdateAsync(provider, wrapper, lyricsText, sourceLanguage, destinationLanguage);
             }
             focusActiveLyric();

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -1,5 +1,4 @@
-// True while the extension's runtime bridge is still attached to this content script.
-// Becomes false after the extension is reloaded/updated, leaving this script orphaned.
+// False after the extension is reloaded/updated and this content script is orphaned.
 function isExtensionAlive() {
     try {
         return Boolean(chrome.runtime && chrome.runtime.id);
@@ -14,36 +13,29 @@ const translationCache = new Map();
 // AI batch translation cache
 const aiBatchCache = new Map();
 
-// In-flight TRANSLATE requests, keyed by cacheKey, so concurrent identical
-// requests (e.g. repeated chorus lines) collapse into a single network call
-// instead of each missing the not-yet-populated cache and firing their own.
+// In-flight TRANSLATE requests keyed by cacheKey, so concurrent identical
+// requests (e.g. repeated chorus lines) share one network call.
 const inFlightTranslations = new Map();
 
 // Active mutation observers
 const mutationObservers = new Map();
 
-// DLX batch fallback: lines that the MutationObserver found uncached are queued
-// here and batch-translated after a short debounce instead of per-line.
+// DLX batch fallback: observer cache-misses queued here, batch-translated
+// after a short debounce.
 const dlxPendingMisses = [];
 let dlxDebounceTimer = null;
 
 // To modify if spotify decides to change variable names
 const lyricLine = "div[data-testid='lyrics-line']";
 
-// True while an AI batch translation is in flight. Used as a re-entrancy guard in
-// translate() so overlapping UI events don't kick off a second pass during the wait.
-// Lines that appear mid-wait are intentionally Google-translated for responsiveness
-// and replaced with the AI result once the batch resolves.
+// True while an AI batch translation is in flight; re-entrancy guard for translate().
 let aiBatchPending = false;
 
-// When true (default), AI mode shows Google translations immediately while the AI
-// batch loads. When false, lyrics stay untranslated until the AI result arrives and
-// the MutationObserver does not Google-translate lines that appear during the wait.
+// When true (default), AI mode shows Google translations while the AI batch loads.
 let aiFailoverEnabled = true;
 
 // Provider-namespaced cache key (google, dlx, customAI) so each provider's
-// results stay separate. The provider is passed explicitly through the call
-// chain, so a pass keeps its namespace even if the user switches mid-pass.
+// cached results stay separate.
 function lineCacheKey(provider, text, sourceLanguage, destinationLanguage) {
     return `${provider}|${text}|${sourceLanguage}|${destinationLanguage}`;
 }
@@ -51,8 +43,7 @@ function lineCacheKey(provider, text, sourceLanguage, destinationLanguage) {
 // Re-entrancy guard for translate(), set before any await.
 let translateInFlight = false;
 
-// Tracks the last song for which an AI batch completed successfully.
-// Prevents re-triggering AI translation for the same song.
+// Last song an AI batch completed for; prevents re-translating it.
 let lastAiSong = null;
 
 function getMainView() {
@@ -187,9 +178,8 @@ async function translateBatchWithAI(lines, sourceLanguage, destinationLanguage) 
     return translations;
 }
 
-// Clear cached translations, then restore and re-translate so fresh results are
-// fetched. scope 'all' wipes every cache; scope 'song' clears only the entries for
-// the currently-playing song.
+// Clear cached translations, then restore and re-translate. scope 'all' wipes
+// every cache; scope 'song' clears only the current song's entries.
 function clearTranslationCache(scope) {
     if (scope === 'all') {
         translationCache.clear();
@@ -201,9 +191,8 @@ function clearTranslationCache(scope) {
             const original = wrapper.querySelector('.originalLyrics');
             const text = original ? original.innerText : (wrapper.firstChild?.textContent || '');
             if (!text) return;
-            // Keys are provider-prefixed (see lineCacheKey) — clear the line
-            // for every registered provider so a re-translate is fresh
-            // regardless of which one is active.
+            // Keys are provider-prefixed (see lineCacheKey) — clear the line for
+            // every registered provider.
             for (const key of translationCache.keys()) {
                 if (Object.keys(TRANSLATION_PROVIDERS).some(id => key.startsWith(`${id}|${text}|`))) {
                     translationCache.delete(key);
@@ -262,15 +251,8 @@ function restoreLyrics() {
 }
 
 
-// This mess is due to Spotify's dynamic lyric highlighting behavior.
-// The provider is captured for the observer's lifetime: every settings change
-// goes through restoreLyrics() -> disconnectAllObservers(), so the next pass
-// recreates the observer with the then-current provider — in-flight callbacks
-// can never mix endpoints or cache namespaces.
-
-// Batch-translate queued DLX cache-miss lines (batch mode) after a short
-// debounce, so the observer sends one request instead of one per line. A batch
-// failure surfaces the error marker and stops — no per-line fan-out, no retry.
+// Batch-translate queued DLX cache-miss lines after a short debounce (one
+// request, not one per line). On failure, show the error marker and stop.
 function scheduleDlxBatch() {
     if (dlxDebounceTimer) clearTimeout(dlxDebounceTimer);
     dlxDebounceTimer = setTimeout(async () => {
@@ -295,8 +277,8 @@ function scheduleDlxBatch() {
             return; // extension context gone
         }
 
-        // Batch mode never fans out to per-line (it would hammer the endpoint):
-        // surface the error marker and leave the queued lines untranslated.
+        // On failure, show the error marker and leave the lines untranslated
+        // (no per-line fan-out).
         if (!response || response.error || !Array.isArray(response.translations)) {
             if (response?.error) console.error('Translatify: DLX observer batch failed:', response.error);
             setTranslateError(true);
@@ -318,9 +300,8 @@ function scheduleDlxBatch() {
 }
 
 async function setupMutationObserver(provider, mode, readProviders) {
-    // Cache namespaces the observer reads, highest priority first. Defaults to
-    // the provider's own; the AI flow passes ['customAI', 'google'] so a
-    // re-rendered line shows the AI result, not the Google failover copy.
+    // Cache namespaces the observer reads, highest priority first (defaults to
+    // the provider's own; the AI flow passes ['customAI', 'google']).
     const readNamespaces = readProviders || [provider];
 
     // Use a single observer that watches the main view for any changes
@@ -352,8 +333,7 @@ async function setupMutationObserver(provider, mode, readProviders) {
             const lyricsText = wrapper.firstChild?.textContent;
             if (!lyricsText) return;
 
-            // Render from cache, checking read namespaces in priority order so
-            // an AI result in 'customAI' wins over the 'google' failover copy.
+            // Render from cache, checking read namespaces in priority order.
             for (const ns of readNamespaces) {
                 const key = lineCacheKey(ns, lyricsText, sourceLanguage, destinationLanguage);
                 if (translationCache.has(key)) {
@@ -389,8 +369,7 @@ async function setupMutationObserver(provider, mode, readProviders) {
                     processWrapper(node);
                 } else {
                     // A full lyrics-page mount adds one container node with the
-                    // lines as descendants (only virtual-scroll additions insert
-                    // lyric lines directly) — translate those too.
+                    // lyric lines as descendants — translate those too.
                     node.querySelectorAll?.(lyricLine).forEach(processWrapper);
                 }
             }
@@ -461,15 +440,13 @@ async function translatePerLine(provider, sourceLanguage, destinationLanguage) {
     await Promise.all(promises);
 
     focusActiveLyric();
-    // translatePerLine is the per-line flow for every provider, so the observer
-    // stays per-line for late lines too (matching the user's per-line choice).
+    // Keep the observer in per-line mode for late lines.
     setupMutationObserver(provider, 'perline');
 }
 
 // Translate the whole lyric sheet in one DLX request (DLX preserves newlines),
-// then render every wrapper from the per-line cache. Much kinder to public DLX
-// instances than one POST per line. Falls back to the per-line flow when the
-// batch fails (network error, endpoint quirk, line-count mismatch).
+// then render every wrapper from the cache. On batch failure, signal
+// runTranslate — no per-line fan-out.
 async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
     const lyricsWrapperList = document.querySelectorAll(lyricLine);
 
@@ -513,11 +490,8 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
         });
     }
 
-    // Render every visible wrapper from the cache. The DOM may have changed
-    // while the request was in flight, so re-query and match by text.
-    // Untranslatable lines (pure punctuation, "♪") are "translated" to
-    // themselves like the per-line flow does, so they get marked and don't
-    // keep the observer's catch-up pass firing forever.
+    // Render every visible wrapper from the cache (re-query — the DOM may have
+    // changed). Untranslatable lines are marked as themselves.
     document.querySelectorAll(lyricLine).forEach(wrapper => {
         if (wrapper.classList.contains("modifedLyricsWrapper")) return;
         const text = wrapper.firstChild?.textContent;
@@ -543,8 +517,8 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
 
     const { songTitle, artistName } = getSongInfo();
     const songId = `${songTitle}|${artistName}|${destinationLanguage}`;
-    // Only trust songId when a title resolved; otherwise different songs
-    // collapse to "||<lang>" and reuse each other's cache.
+    // Only trust songId when a title resolved (otherwise different songs
+    // collapse to "||<lang>").
     const hasSongId = songTitle !== '';
 
     // If AI already translated this song, just render visible wrappers from
@@ -567,18 +541,14 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     const wrappers = Array.from(lyricsWrapperList);
     const lines = wrappers.map(w => w.firstChild?.textContent || '');
 
-    // Start the MutationObserver now so that lyrics appearing during the AI
-    // call get Google-translated immediately.  Once the AI batch completes,
-    // all visible translations are replaced with the AI results. It reads
-    // 'customAI' first, then 'google', so re-rendered lines prefer the AI text.
+    // Start the observer now so lyrics appearing during the AI call get
+    // Google-translated; it reads 'customAI' first, then 'google'.
     setupMutationObserver('google', undefined, ['customAI', 'google']);
 
     aiBatchPending = true;
 
-    // Failover (on by default): Google-translate ALL current lyrics concurrently while
-    // the (slower) AI batch runs, so the user sees results immediately instead of
-    // staring at a blank wait. This renders progressively; the AI result overwrites it
-    // once it lands. When disabled, lyrics stay untranslated until the AI result arrives.
+    // Failover (on by default): Google-translate all lyrics while the AI batch
+    // runs; the AI result overwrites them once it lands.
     try {
         const stored = await chrome.storage.local.get(['aiFailover']);
         aiFailoverEnabled = stored.aiFailover !== undefined ? stored.aiFailover : true;
@@ -597,8 +567,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
 
     if (!translations || !Array.isArray(translations)) {
         console.warn('Translatify: AI batch returned non-array, falling back to Google');
-        // With failover on, the Google pass already translated every line — just let it
-        // finish. With failover off, nothing was translated, so run Google now.
+        // Failover on: let the Google pass finish. Off: run Google now.
         if (aiFailoverEnabled) {
             await googlePass;
         } else {
@@ -610,8 +579,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
 
     if (hasSongId) lastAiSong = songId;
 
-    // Let every Google response land before making the AI result authoritative, so a
-    // late Google write can't clobber the AI translation in translationCache.
+    // Let the Google pass finish before caching the AI results.
     await googlePass;
 
     // Cache the AI batch results under Custom AI's 'customAI' namespace; the
@@ -622,11 +590,9 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
         }
     }
 
-    // Render all currently-visible wrappers.  The DOM may have changed during
-    // the AI call (Spotify virtual scrolling), so re-query and match by text.
-    // Wrappers already translated by Google (aiBatchPending was off, so the
-    // MutationObserver ran Google fallback) get their text updated in-place
-    // with the AI result.  Unmodified wrappers get the full replaceLyric treatment.
+    // Render all visible wrappers (re-query — the DOM may have changed).
+    // Already-translated wrappers get their text updated in place; others
+    // get replaceLyric.
     const currentWrappers = Array.from(document.querySelectorAll(lyricLine));
     currentWrappers.forEach(wrapper => {
         const text = wrapper.firstChild?.textContent || '';
@@ -652,8 +618,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
 async function translate() {
     if (!isExtensionAlive()) return;
 
-    // Prevent overlapping calls — translate() fires on many UI events, and the
-    // guard must be set before runTranslate's awaits to be effective.
+    // Prevent overlapping calls; the guard must be set before runTranslate's awaits.
     if (aiBatchPending || translateInFlight) return;
     translateInFlight = true;
     try {
@@ -664,8 +629,7 @@ async function translate() {
 }
 
 async function runTranslate() {
-    // Skip if all visible lyrics are already translated — prevents
-    // unnecessary re-translation when clicking unrelated UI elements.
+    // Skip if all visible lyrics are already translated.
     const visibleWrappers = document.querySelectorAll(lyricLine);
     if (visibleWrappers.length > 0) {
         const allTranslated = Array.from(visibleWrappers).every(w =>
@@ -689,14 +653,12 @@ async function runTranslate() {
 
 
     if (translateButton.getAttribute("aria-pressed") == "true" && lyricsButton.getAttribute("data-active") == "true") {
-        // Resolve the provider once per pass from the registry: the configured
-        // provider when its required settings are present, Google otherwise
-        // (no provider errors line-by-line into the void). The resolved id is
-        // passed down explicitly from here.
+        // Resolve the provider from the registry: the configured one when its
+        // required settings are present, Google otherwise.
         const settings = await chrome.storage.local.get(PROVIDER_SETTING_KEYS);
         const resolved = resolveTranslationProvider(settings);
         const mode = resolveTranslationMode(resolved, settings);
-        // Show the loading indicator only while lyrics are actually being fetched/rendered.
+        // Show the loading indicator while lyrics are fetched/rendered.
         setTranslatingIndicator(true);
         let providerErrored = false;
         try {
@@ -710,10 +672,8 @@ async function runTranslate() {
         } finally {
             setTranslatingIndicator(false);
         }
-        // Swap the loading dots for an error marker when the provider's batch
-        // failed (AI or DLX), or when the configured provider is misconfigured
-        // and this pass quietly used Google instead — so the user can tell
-        // something is off rather than assuming their provider did the work.
+        // Show the error marker when the provider's batch failed, or when a
+        // misconfigured provider fell back to Google.
         if (resolved.fallback) {
             console.warn(`Translatify: provider "${settings.translationProvider}" is missing required settings, used ${resolved.id} instead`);
         }

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -24,6 +24,9 @@ const mutationObservers = new Map();
 // after a short debounce.
 const dlxPendingMisses = [];
 let dlxDebounceTimer = null;
+// True while a DLX request is in flight; keeps the observer from firing another
+// batch (or per-line requests) until it finishes.
+let dlxBatchInFlight = false;
 
 // To modify if spotify decides to change variable names
 const lyricLine = "div[data-testid='lyrics-line']";
@@ -218,9 +221,10 @@ function disconnectAllObservers() {
         console.log('Disconnected observer for:', key);
     });
     mutationObservers.clear();
-    // Flush pending DLX batch fallback
+    // Clear pending DLX batch state.
     if (dlxDebounceTimer) { clearTimeout(dlxDebounceTimer); dlxDebounceTimer = null; }
     dlxPendingMisses.length = 0;
+    dlxBatchInFlight = false;
 }
 
 function restoreLyrics() {
@@ -255,48 +259,60 @@ function restoreLyrics() {
 // request, not one per line). On failure, show the error marker and stop.
 function scheduleDlxBatch() {
     if (dlxDebounceTimer) clearTimeout(dlxDebounceTimer);
-    dlxDebounceTimer = setTimeout(async () => {
-        const pending = dlxPendingMisses.splice(0);
-        console.log('Translatify: DLX observer batch executing for', pending.length, 'lines');
-        if (pending.length === 0 || !isExtensionAlive()) return;
+    dlxDebounceTimer = setTimeout(runDlxObserverBatch, 200);
+}
 
-        const sourceLanguage = pending[0].sourceLanguage;
-        const destinationLanguage = pending[0].destinationLanguage;
-        const uniqueLines = [...new Set(pending.map(p => p.lyricsText))];
+async function runDlxObserverBatch() {
+    // One DLX request at a time: while a batch is in flight, leave the misses
+    // queued — the running batch flushes them when it finishes.
+    if (dlxBatchInFlight) return;
 
-        let response;
-        try {
-            response = await chrome.runtime.sendMessage({
-                type: 'TRANSLATE',
-                provider: 'dlx',
-                lines: uniqueLines,
-                sourceLanguage,
-                destinationLanguage
-            });
-        } catch {
-            return; // extension context gone
-        }
+    const pending = dlxPendingMisses.splice(0);
+    console.log('Translatify: DLX observer batch executing for', pending.length, 'lines');
+    if (pending.length === 0 || !isExtensionAlive()) return;
 
-        // On failure, show the error marker and leave the lines untranslated
-        // (no per-line fan-out).
-        if (!response || response.error || !Array.isArray(response.translations)) {
-            if (response?.error) console.error('Translatify: DLX observer batch failed:', response.error);
-            setTranslateError(true);
-            return;
-        }
+    const sourceLanguage = pending[0].sourceLanguage;
+    const destinationLanguage = pending[0].destinationLanguage;
+    const uniqueLines = [...new Set(pending.map(p => p.lyricsText))];
 
-        uniqueLines.forEach((text, i) => {
-            if (response.translations[i] != null) {
-                translationCache.set(lineCacheKey('dlx', text, sourceLanguage, destinationLanguage), response.translations[i]);
-            }
+    let response;
+    dlxBatchInFlight = true;
+    try {
+        response = await chrome.runtime.sendMessage({
+            type: 'TRANSLATE',
+            provider: 'dlx',
+            lines: uniqueLines,
+            sourceLanguage,
+            destinationLanguage
         });
+    } catch {
+        return; // extension context gone
+    } finally {
+        dlxBatchInFlight = false;
+    }
 
-        pending.forEach(({ wrapper, lyricsText }) => {
-            if (wrapper.classList.contains("modifedLyricsWrapper")) return;
-            const translated = translationCache.get(lineCacheKey('dlx', lyricsText, sourceLanguage, destinationLanguage));
-            if (translated != null) replaceLyric(translated, wrapper);
-        });
-    }, 200);
+    // On failure, show the error marker and leave the lines untranslated
+    // (no per-line fan-out).
+    if (!response || response.error || !Array.isArray(response.translations)) {
+        if (response?.error) console.error('Translatify: DLX observer batch failed:', response.error);
+        setTranslateError(true);
+        return;
+    }
+
+    uniqueLines.forEach((text, i) => {
+        if (response.translations[i] != null) {
+            translationCache.set(lineCacheKey('dlx', text, sourceLanguage, destinationLanguage), response.translations[i]);
+        }
+    });
+
+    pending.forEach(({ wrapper, lyricsText }) => {
+        if (wrapper.classList.contains("modifedLyricsWrapper")) return;
+        const translated = translationCache.get(lineCacheKey('dlx', lyricsText, sourceLanguage, destinationLanguage));
+        if (translated != null) replaceLyric(translated, wrapper);
+    });
+
+    // Flush misses that queued while this batch was in flight.
+    if (dlxPendingMisses.length > 0) scheduleDlxBatch();
 }
 
 async function setupMutationObserver(provider, mode, readProviders) {
@@ -466,6 +482,7 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
     if (uncached.length > 0) {
         if (!isExtensionAlive()) return;
         let response;
+        dlxBatchInFlight = true;
         try {
             response = await chrome.runtime.sendMessage({
                 type: 'TRANSLATE',
@@ -476,6 +493,8 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
             });
         } catch {
             response = null;
+        } finally {
+            dlxBatchInFlight = false;
         }
 
         if (!response || response.error || !Array.isArray(response.translations)) {
@@ -504,6 +523,8 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
 
     focusActiveLyric();
     setupMutationObserver('dlx', 'batch');
+    // Flush observer misses that queued while the batch was in flight.
+    if (dlxPendingMisses.length > 0) scheduleDlxBatch();
 }
 
 // Batch translate all lyrics with AI, then render them

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -296,9 +296,7 @@ async function setupMutationObserver(provider) {
             const cacheKey = lineCacheKey(provider, lyricsText, sourceLanguage, destinationLanguage);
             if (translationCache.has(cacheKey)) {
                 replaceLyric(translationCache.get(cacheKey), wrapper);
-            } else if (!(aiBatchPending && !aiFailoverEnabled)) {
-                // Skip Google fallback for new lines while an AI batch is in flight
-                // and failover is disabled — the AI result will translate them.
+            } else if (provider !== 'dlx' && !(aiBatchPending && !aiFailoverEnabled)) {
                 translateAndUpdateAsync(provider, wrapper, lyricsText, sourceLanguage, destinationLanguage);
             }
             focusActiveLyric();

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -41,6 +41,14 @@ let aiFailoverEnabled = true;
 // (the DLX endpoint — no API key required). "customAI" is handled separately via the batch flow.
 let activeProvider = 'google';
 
+// Cache keys are namespaced by the active provider so switching providers
+// (google <-> dlx) never serves the other provider's cached results. The AI
+// batch flow runs with activeProvider 'google', so AI results intentionally
+// land in (and overwrite) the google entries its failover pre-pass wrote.
+function lineCacheKey(text, sourceLanguage, destinationLanguage) {
+    return `${activeProvider}|${text}|${sourceLanguage}|${destinationLanguage}`;
+}
+
 // Re-entrancy guard for translate(), set before any await.
 let translateInFlight = false;
 
@@ -89,7 +97,7 @@ function isUntranslatable(text) {
 async function translateText(text, sourceLanguage, destinationLanguage) {
     if (isUntranslatable(text)) return text;
 
-    const cacheKey = `${text}|${sourceLanguage}|${destinationLanguage}`;
+    const cacheKey = lineCacheKey(text, sourceLanguage, destinationLanguage);
     if (translationCache.has(cacheKey)) {
         return translationCache.get(cacheKey);
     }
@@ -200,8 +208,11 @@ function clearTranslationCache(scope) {
             const original = wrapper.querySelector('.originalLyrics');
             const text = original ? original.innerText : (wrapper.firstChild?.textContent || '');
             if (!text) return;
+            // Keys are provider-prefixed (see lineCacheKey) — clear the line
+            // for every provider so a re-translate is fresh regardless of which
+            // one is active.
             for (const key of translationCache.keys()) {
-                if (key.startsWith(`${text}|`)) translationCache.delete(key);
+                if (key.startsWith(`google|${text}|`) || key.startsWith(`dlx|${text}|`)) translationCache.delete(key);
             }
         });
         // Drop AI batch entries for the current song (key ends with |<songTitle>).
@@ -278,24 +289,34 @@ async function setupMutationObserver() {
         const translateButton = document.querySelector("button[data-testid='translate-button']");
         if (!translateButton || translateButton.getAttribute("aria-pressed") !== "true") return;
 
+        const processWrapper = (wrapper) => {
+            if (wrapper.classList.contains("modifedLyricsWrapper")) return;
+
+            const lyricsText = wrapper.firstChild?.textContent;
+            if (!lyricsText) return;
+
+            const cacheKey = lineCacheKey(lyricsText, sourceLanguage, destinationLanguage);
+            if (translationCache.has(cacheKey)) {
+                replaceLyric(translationCache.get(cacheKey), wrapper);
+            } else if (!(aiBatchPending && !aiFailoverEnabled)) {
+                // Skip Google fallback for new lines while an AI batch is in flight
+                // and failover is disabled — the AI result will translate them.
+                translateAndUpdateAsync(wrapper, lyricsText, sourceLanguage, destinationLanguage);
+            }
+            focusActiveLyric();
+        };
+
         for (const mutation of mutations) {
             for (const node of mutation.addedNodes) {
                 if (node.nodeType !== Node.ELEMENT_NODE) continue;
-                if (!node.matches?.(lyricLine)) continue;
-                if (node.classList.contains("modifedLyricsWrapper")) continue;
-
-                const lyricsText = node.firstChild?.textContent;
-                if (!lyricsText) continue;
-
-                const cacheKey = `${lyricsText}|${sourceLanguage}|${destinationLanguage}`;
-                if (translationCache.has(cacheKey)) {
-                    replaceLyric(translationCache.get(cacheKey), node);
-                } else if (!(aiBatchPending && !aiFailoverEnabled)) {
-                    // Skip Google fallback for new lines while an AI batch is in flight
-                    // and failover is disabled — the AI result will translate them.
-                    translateAndUpdateAsync(node, lyricsText, sourceLanguage, destinationLanguage);
+                if (node.matches?.(lyricLine)) {
+                    processWrapper(node);
+                } else {
+                    // A full lyrics-page mount adds one container node with the
+                    // lines as descendants (only virtual-scroll additions insert
+                    // lyric lines directly) — translate those too.
+                    node.querySelectorAll?.(lyricLine).forEach(processWrapper);
                 }
-                focusActiveLyric();
             }
         }
     });
@@ -389,7 +410,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
         currentWrappers.forEach(wrapper => {
             if (wrapper.classList.contains("modifedLyricsWrapper")) return;
             const text = wrapper.firstChild?.textContent || '';
-            const cacheKey = `${text}|${sourceLanguage}|${destinationLanguage}`;
+            const cacheKey = lineCacheKey(text, sourceLanguage, destinationLanguage);
             const cached = translationCache.get(cacheKey);
             if (cached != null) {
                 replaceLyric(cached, wrapper);
@@ -452,7 +473,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     // up AI translations instead of falling back to Google.
     for (let i = 0; i < lines.length; i++) {
         if (translations[i] != null && lines[i]) {
-            translationCache.set(`${lines[i]}|${sourceLanguage}|${destinationLanguage}`, translations[i]);
+            translationCache.set(lineCacheKey(lines[i], sourceLanguage, destinationLanguage), translations[i]);
         }
     }
 
@@ -523,12 +544,14 @@ async function runTranslate() {
 
 
     if (translateButton.getAttribute("aria-pressed") == "true" && lyricsButton.getAttribute("data-active") == "true") {
-        // Gate on provider + endpoint; the background reads the rest and falls
-        // back to Google if it isn't configured.
-        const settings = await chrome.storage.local.get(['translationProvider', 'aiEndpoint']);
+        // Gate each provider on its required settings and stay on Google when
+        // they're missing: TRANSLATE_DLX has no fallback of its own in the
+        // background, so routing there without an endpoint would just error on
+        // every line and leave the lyrics untranslated.
+        const settings = await chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'dlxEndpoint']);
         // Make the active provider visible to translateText() so per-line calls
         // (both in the live pass and the MutationObserver) use the right endpoint.
-        activeProvider = settings.translationProvider === 'dlx' ? 'dlx' : 'google';
+        activeProvider = (settings.translationProvider === 'dlx' && settings.dlxEndpoint) ? 'dlx' : 'google';
         // Show the loading indicator only while lyrics are actually being fetched/rendered.
         setTranslatingIndicator(true);
         let aiErrored = false;

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -36,23 +36,16 @@ let aiBatchPending = false;
 // the MutationObserver does not Google-translate lines that appear during the wait.
 let aiFailoverEnabled = true;
 
-// Active translation provider for the current pass. "google" uses TRANSLATE messages
-// (Google endpoints); "dlx" routes the same line-by-line path through TRANSLATE_DLX
-// (the DLX endpoint — no API key required). "customAI" is handled separately via the batch flow.
-let activeProvider = 'google';
-
-// Cache keys are namespaced by the active provider so switching providers
-// (google <-> dlx) never serves the other provider's cached results. The AI
-// batch flow runs with activeProvider 'google', so AI results intentionally
-// land in (and overwrite) the google entries its failover pre-pass wrote.
-function lineCacheKey(text, sourceLanguage, destinationLanguage) {
-    return `${activeProvider}|${text}|${sourceLanguage}|${destinationLanguage}`;
+// Cache keys are namespaced by provider so switching providers (google <-> dlx)
+// never serves the other provider's cached results. The provider is passed
+// explicitly through the whole call chain (no mutable module state), so a pass
+// keeps using the provider it started with even if the user switches mid-pass.
+// The AI flow deliberately uses 'google' here: its results overwrite the
+// entries the Google failover pre-pass wrote, and the MutationObserver reads
+// them back from the same namespace.
+function lineCacheKey(provider, text, sourceLanguage, destinationLanguage) {
+    return `${provider}|${text}|${sourceLanguage}|${destinationLanguage}`;
 }
-
-// Whether DLX translates the whole sheet in one request ('batch', the default)
-// or one request per line ('perline'). User choice, stored as dlxTranslationMode;
-// refreshed on every pass in runTranslate().
-let dlxBatchEnabled = true;
 
 // Re-entrancy guard for translate(), set before any await.
 let translateInFlight = false;
@@ -99,10 +92,10 @@ function isUntranslatable(text) {
     return !text || !/\p{L}|\p{N}/u.test(text);
 }
 
-async function translateText(text, sourceLanguage, destinationLanguage) {
+async function translateText(provider, text, sourceLanguage, destinationLanguage) {
     if (isUntranslatable(text)) return text;
 
-    const cacheKey = lineCacheKey(text, sourceLanguage, destinationLanguage);
+    const cacheKey = lineCacheKey(provider, text, sourceLanguage, destinationLanguage);
     if (translationCache.has(cacheKey)) {
         return translationCache.get(cacheKey);
     }
@@ -117,10 +110,10 @@ async function translateText(text, sourceLanguage, destinationLanguage) {
     const requestPromise = (async () => {
         let response;
         try {
-            const messageType = activeProvider === 'dlx' ? 'TRANSLATE_DLX' : 'TRANSLATE';
             response = await chrome.runtime.sendMessage({
-                type: messageType,
-                text,
+                type: 'TRANSLATE',
+                provider,
+                lines: [text],
                 sourceLanguage,
                 destinationLanguage
             });
@@ -128,13 +121,15 @@ async function translateText(text, sourceLanguage, destinationLanguage) {
             return null;
         }
 
-        if (!response || response.error) {
+        if (!response || response.error || !Array.isArray(response.translations)) {
             if (response?.error) console.error('Error:', response.error);
             return null;
         }
 
-        translationCache.set(cacheKey, response.result);
-        return response.result;
+        const result = response.translations[0];
+        if (result == null) return null;
+        translationCache.set(cacheKey, result);
+        return result;
     })();
 
     inFlightTranslations.set(cacheKey, requestPromise);
@@ -169,7 +164,8 @@ async function translateBatchWithAI(lines, sourceLanguage, destinationLanguage) 
     let response;
     try {
         response = await chrome.runtime.sendMessage({
-            type: 'TRANSLATE_BATCH',
+            type: 'TRANSLATE',
+            provider: 'customAI',
             lines,
             songTitle,
             artistName,
@@ -205,10 +201,12 @@ function clearTranslationCache(scope) {
             const text = original ? original.innerText : (wrapper.firstChild?.textContent || '');
             if (!text) return;
             // Keys are provider-prefixed (see lineCacheKey) — clear the line
-            // for every provider so a re-translate is fresh regardless of which
-            // one is active.
+            // for every registered provider so a re-translate is fresh
+            // regardless of which one is active.
             for (const key of translationCache.keys()) {
-                if (key.startsWith(`google|${text}|`) || key.startsWith(`dlx|${text}|`)) translationCache.delete(key);
+                if (Object.keys(TRANSLATION_PROVIDERS).some(id => key.startsWith(`${id}|${text}|`))) {
+                    translationCache.delete(key);
+                }
             }
         });
         // Drop AI batch entries for the current song (key ends with |<songTitle>).
@@ -260,8 +258,12 @@ function restoreLyrics() {
 }
 
 
-// This mess is due to Spotify's dynamic lyric highlighting behavior
-async function setupMutationObserver() {
+// This mess is due to Spotify's dynamic lyric highlighting behavior.
+// The provider is captured for the observer's lifetime: every settings change
+// goes through restoreLyrics() -> disconnectAllObservers(), so the next pass
+// recreates the observer with the then-current provider — in-flight callbacks
+// can never mix endpoints or cache namespaces.
+async function setupMutationObserver(provider) {
     // Use a single observer that watches the main view for any changes
     const observerKey = `mainView`;
 
@@ -291,13 +293,13 @@ async function setupMutationObserver() {
             const lyricsText = wrapper.firstChild?.textContent;
             if (!lyricsText) return;
 
-            const cacheKey = lineCacheKey(lyricsText, sourceLanguage, destinationLanguage);
+            const cacheKey = lineCacheKey(provider, lyricsText, sourceLanguage, destinationLanguage);
             if (translationCache.has(cacheKey)) {
                 replaceLyric(translationCache.get(cacheKey), wrapper);
             } else if (!(aiBatchPending && !aiFailoverEnabled)) {
                 // Skip Google fallback for new lines while an AI batch is in flight
                 // and failover is disabled — the AI result will translate them.
-                translateAndUpdateAsync(wrapper, lyricsText, sourceLanguage, destinationLanguage);
+                translateAndUpdateAsync(provider, wrapper, lyricsText, sourceLanguage, destinationLanguage);
             }
             focusActiveLyric();
         };
@@ -351,9 +353,9 @@ function replaceLyric(translatedLine, lyricsWrapper) {
     newLyrics.classList.add("newLyrics");
 }
 
-async function translateAndUpdateAsync(lyricsWrapper, lyricsText, sourceLanguage, destinationLanguage) {
+async function translateAndUpdateAsync(provider, lyricsWrapper, lyricsText, sourceLanguage, destinationLanguage) {
     try {
-        const translatedLine = await translateText(lyricsText, sourceLanguage, destinationLanguage);
+        const translatedLine = await translateText(provider, lyricsText, sourceLanguage, destinationLanguage);
         if (translatedLine != null) {
             replaceLyric(translatedLine, lyricsWrapper);
         }
@@ -362,9 +364,9 @@ async function translateAndUpdateAsync(lyricsWrapper, lyricsText, sourceLanguage
     }
 }
 
-// Translate every visible lyric line, then attach the mutation observer to
-// translate any new lines Spotify renders later.
-async function translateLineByLineWithGoogle(sourceLanguage, destinationLanguage) {
+// Translate every visible lyric line with the given provider, then attach the
+// mutation observer to translate any new lines Spotify renders later.
+async function translatePerLine(provider, sourceLanguage, destinationLanguage) {
     const lyricsWrapperList = document.querySelectorAll(lyricLine);
 
     if (lyricsWrapperList.length === 0) {
@@ -375,13 +377,13 @@ async function translateLineByLineWithGoogle(sourceLanguage, destinationLanguage
     const promises = Array.from(lyricsWrapperList).map(async (wrapper) => {
         const lyrics = wrapper.firstChild?.textContent;
         if (!lyrics) return;
-        const translatedLine = await translateText(lyrics, sourceLanguage, destinationLanguage);
+        const translatedLine = await translateText(provider, lyrics, sourceLanguage, destinationLanguage);
         if (translatedLine != null) replaceLyric(translatedLine, wrapper);
     });
     await Promise.all(promises);
 
     focusActiveLyric();
-    setupMutationObserver();
+    setupMutationObserver(provider);
 }
 
 // Translate the whole lyric sheet in one DLX request (DLX preserves newlines),
@@ -401,7 +403,7 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
         Array.from(lyricsWrapperList)
             .map(w => w.firstChild?.textContent)
             .filter(text => text && !isUntranslatable(text) &&
-                !translationCache.has(lineCacheKey(text, sourceLanguage, destinationLanguage)))
+                !translationCache.has(lineCacheKey('dlx', text, sourceLanguage, destinationLanguage)))
     )];
 
     if (uncached.length > 0) {
@@ -409,7 +411,8 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
         let response;
         try {
             response = await chrome.runtime.sendMessage({
-                type: 'TRANSLATE_DLX_BATCH',
+                type: 'TRANSLATE',
+                provider: 'dlx',
                 lines: uncached,
                 sourceLanguage,
                 destinationLanguage
@@ -420,12 +423,12 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
 
         if (!response || response.error || !Array.isArray(response.translations)) {
             if (response?.error) console.error('Translatify: DLX batch failed, falling back to per-line:', response.error);
-            return translateLineByLineWithGoogle(sourceLanguage, destinationLanguage);
+            return translatePerLine('dlx', sourceLanguage, destinationLanguage);
         }
 
         uncached.forEach((text, i) => {
             if (response.translations[i] != null) {
-                translationCache.set(lineCacheKey(text, sourceLanguage, destinationLanguage), response.translations[i]);
+                translationCache.set(lineCacheKey('dlx', text, sourceLanguage, destinationLanguage), response.translations[i]);
             }
         });
     }
@@ -441,12 +444,12 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
         if (!text) return;
         const translated = isUntranslatable(text)
             ? text
-            : translationCache.get(lineCacheKey(text, sourceLanguage, destinationLanguage));
+            : translationCache.get(lineCacheKey('dlx', text, sourceLanguage, destinationLanguage));
         if (translated != null) replaceLyric(translated, wrapper);
     });
 
     focusActiveLyric();
-    setupMutationObserver();
+    setupMutationObserver('dlx');
 }
 
 // Batch translate all lyrics with AI, then render them
@@ -471,7 +474,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
         currentWrappers.forEach(wrapper => {
             if (wrapper.classList.contains("modifedLyricsWrapper")) return;
             const text = wrapper.firstChild?.textContent || '';
-            const cacheKey = lineCacheKey(text, sourceLanguage, destinationLanguage);
+            const cacheKey = lineCacheKey('google', text, sourceLanguage, destinationLanguage);
             const cached = translationCache.get(cacheKey);
             if (cached != null) {
                 replaceLyric(cached, wrapper);
@@ -487,7 +490,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     // Start the MutationObserver now so that lyrics appearing during the AI
     // call get Google-translated immediately.  Once the AI batch completes,
     // all visible translations are replaced with the AI results.
-    setupMutationObserver();
+    setupMutationObserver('google');
 
     aiBatchPending = true;
 
@@ -503,7 +506,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     }
 
     const googlePass = aiFailoverEnabled
-        ? translateLineByLineWithGoogle(sourceLanguage, destinationLanguage)
+        ? translatePerLine('google', sourceLanguage, destinationLanguage)
             .catch(err => console.error('Translatify: Google pre-pass error:', err))
         : Promise.resolve();
 
@@ -518,7 +521,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
         if (aiFailoverEnabled) {
             await googlePass;
         } else {
-            await translateLineByLineWithGoogle(sourceLanguage, destinationLanguage);
+            await translatePerLine('google', sourceLanguage, destinationLanguage);
         }
         // Signal that the AI endpoint failed so the button can show an error marker.
         return false;
@@ -534,7 +537,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     // up AI translations instead of falling back to Google.
     for (let i = 0; i < lines.length; i++) {
         if (translations[i] != null && lines[i]) {
-            translationCache.set(lineCacheKey(lines[i], sourceLanguage, destinationLanguage), translations[i]);
+            translationCache.set(lineCacheKey('google', lines[i], sourceLanguage, destinationLanguage), translations[i]);
         }
     }
 
@@ -546,7 +549,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     const currentWrappers = Array.from(document.querySelectorAll(lyricLine));
     currentWrappers.forEach(wrapper => {
         const text = wrapper.firstChild?.textContent || '';
-        const cacheKey = `${text}|${sourceLanguage}|${destinationLanguage}`;
+        const cacheKey = lineCacheKey('google', text, sourceLanguage, destinationLanguage);
         const aiTranslation = translationCache.get(cacheKey);
         if (aiTranslation == null) return;
 
@@ -561,7 +564,7 @@ async function translateBatchWithAIAndRender(sourceLanguage, destinationLanguage
     });
 
     focusActiveLyric();
-    setupMutationObserver();
+    setupMutationObserver('google');
 }
 
 // MAIN TRANSLATION FUNCTION
@@ -605,34 +608,35 @@ async function runTranslate() {
 
 
     if (translateButton.getAttribute("aria-pressed") == "true" && lyricsButton.getAttribute("data-active") == "true") {
-        // Gate each provider on its required settings and stay on Google when
-        // they're missing: TRANSLATE_DLX has no fallback of its own in the
-        // background, so routing there without an endpoint would just error on
-        // every line and leave the lyrics untranslated.
-        const settings = await chrome.storage.local.get(['translationProvider', 'aiEndpoint', 'dlxEndpoint', 'dlxTranslationMode']);
-        // Make the active provider visible to translateText() so per-line calls
-        // (both in the live pass and the MutationObserver) use the right endpoint.
-        activeProvider = (settings.translationProvider === 'dlx' && settings.dlxEndpoint) ? 'dlx' : 'google';
-        dlxBatchEnabled = settings.dlxTranslationMode !== 'perline';
+        // Resolve the provider once per pass from the registry: the configured
+        // provider when its required settings are present, Google otherwise
+        // (no provider errors line-by-line into the void). The resolved id is
+        // passed down explicitly from here.
+        const settings = await chrome.storage.local.get(PROVIDER_SETTING_KEYS);
+        const resolved = resolveTranslationProvider(settings);
+        const mode = resolveTranslationMode(resolved, settings);
         // Show the loading indicator only while lyrics are actually being fetched/rendered.
         setTranslatingIndicator(true);
         let aiErrored = false;
         try {
-            if (settings.translationProvider === 'customAI' && settings.aiEndpoint) {
-                // AI batch uses its own provider-aware flow; restore line-by-line
-                // defaults for the failover pre-pass so Google still works there.
-                activeProvider = 'google';
+            if (resolved.id === 'customAI') {
                 aiErrored = (await translateBatchWithAIAndRender(sourceLanguage, destinationLanguage)) === false;
-            } else if (activeProvider === 'dlx' && dlxBatchEnabled) {
+            } else if (resolved.id === 'dlx' && mode === 'batch') {
                 await translateBatchWithDlx(sourceLanguage, destinationLanguage);
             } else {
-                await translateLineByLineWithGoogle(sourceLanguage, destinationLanguage);
+                await translatePerLine(resolved.id, sourceLanguage, destinationLanguage);
             }
         } finally {
             setTranslatingIndicator(false);
         }
-        // Swap the loading dots for an error marker when the AI endpoint failed.
-        if (aiErrored) setTranslateError(true);
+        // Swap the loading dots for an error marker when the AI endpoint
+        // failed, or when the configured provider is misconfigured and this
+        // pass quietly used Google instead — so the user can tell something
+        // is off rather than assuming their provider did the work.
+        if (resolved.fallback) {
+            console.warn(`Translatify: provider "${settings.translationProvider}" is missing required settings, used ${resolved.id} instead`);
+        }
+        if (aiErrored || resolved.fallback) setTranslateError(true);
     } else if (translateButton.getAttribute("aria-pressed") == "false") {
         setTranslateError(false);
         restoreLyrics();

--- a/scripts/lyricsTranslator.js
+++ b/scripts/lyricsTranslator.js
@@ -272,13 +272,14 @@ function restoreLyrics() {
 // recreates the observer with the then-current provider — in-flight callbacks
 // can never mix endpoints or cache namespaces.
 
-// Batch-translate queued DLX cache-miss lines after a short debounce so the
-// observer never fires per-line requests (which would give inconsistent results).
+// Batch-translate queued DLX cache-miss lines (batch mode) after a short
+// debounce, so the observer sends one request instead of one per line. A batch
+// failure surfaces the error marker and stops — no per-line fan-out, no retry.
 function scheduleDlxBatch() {
     if (dlxDebounceTimer) clearTimeout(dlxDebounceTimer);
     dlxDebounceTimer = setTimeout(async () => {
         const pending = dlxPendingMisses.splice(0);
-        console.log('Translatify: DLX fallback batch executing for', pending.length, 'lines');
+        console.log('Translatify: DLX observer batch executing for', pending.length, 'lines');
         if (pending.length === 0 || !isExtensionAlive()) return;
 
         const sourceLanguage = pending[0].sourceLanguage;
@@ -295,10 +296,16 @@ function scheduleDlxBatch() {
                 destinationLanguage
             });
         } catch {
-            return;
+            return; // extension context gone
         }
 
-        if (!response || response.error || !Array.isArray(response.translations)) return;
+        // Batch mode never fans out to per-line (it would hammer the endpoint):
+        // surface the error marker and leave the queued lines untranslated.
+        if (!response || response.error || !Array.isArray(response.translations)) {
+            if (response?.error) console.error('Translatify: DLX observer batch failed:', response.error);
+            setTranslateError(true);
+            return;
+        }
 
         uniqueLines.forEach((text, i) => {
             if (response.translations[i] != null) {
@@ -314,7 +321,7 @@ function scheduleDlxBatch() {
     }, 200);
 }
 
-async function setupMutationObserver(provider) {
+async function setupMutationObserver(provider, mode) {
     // Use a single observer that watches the main view for any changes
     const observerKey = `mainView`;
 
@@ -348,8 +355,18 @@ async function setupMutationObserver(provider) {
             if (translationCache.has(cacheKey)) {
                 replaceLyric(translationCache.get(cacheKey), wrapper);
             } else if (provider === 'dlx') {
-                dlxPendingMisses.push({ wrapper, lyricsText, sourceLanguage, destinationLanguage });
-                scheduleDlxBatch();
+                // Untranslatable lines (♪, pure punctuation) are marked as
+                // themselves; only real text needs a DLX request.
+                if (isUntranslatable(lyricsText)) {
+                    replaceLyric(lyricsText, wrapper);
+                } else if (mode === 'batch') {
+                    // Queue for one debounced batch request per burst of new lines.
+                    dlxPendingMisses.push({ wrapper, lyricsText, sourceLanguage, destinationLanguage });
+                    scheduleDlxBatch();
+                } else {
+                    // Per-line mode: honor the user's choice for late lines too.
+                    translateAndUpdateAsync('dlx', wrapper, lyricsText, sourceLanguage, destinationLanguage);
+                }
             } else if (!(aiBatchPending && !aiFailoverEnabled)) {
                 translateAndUpdateAsync(provider, wrapper, lyricsText, sourceLanguage, destinationLanguage);
             }
@@ -435,7 +452,9 @@ async function translatePerLine(provider, sourceLanguage, destinationLanguage) {
     await Promise.all(promises);
 
     focusActiveLyric();
-    setupMutationObserver(provider);
+    // translatePerLine is the per-line flow for every provider, so the observer
+    // stays per-line for late lines too (matching the user's per-line choice).
+    setupMutationObserver(provider, 'perline');
 }
 
 // Translate the whole lyric sheet in one DLX request (DLX preserves newlines),
@@ -474,8 +493,8 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
         }
 
         if (!response || response.error || !Array.isArray(response.translations)) {
-            if (response?.error) console.error('Translatify: DLX batch failed, falling back to per-line:', response.error);
-            return translatePerLine('dlx', sourceLanguage, destinationLanguage);
+            if (response?.error) console.error('Translatify: DLX batch failed:', response.error);
+            return false;   // signal failure to runTranslate; no per-line fan-out, no retry
         }
 
         uncached.forEach((text, i) => {
@@ -501,7 +520,7 @@ async function translateBatchWithDlx(sourceLanguage, destinationLanguage) {
     });
 
     focusActiveLyric();
-    setupMutationObserver('dlx');
+    setupMutationObserver('dlx', 'batch');
 }
 
 // Batch translate all lyrics with AI, then render them
@@ -669,26 +688,26 @@ async function runTranslate() {
         const mode = resolveTranslationMode(resolved, settings);
         // Show the loading indicator only while lyrics are actually being fetched/rendered.
         setTranslatingIndicator(true);
-        let aiErrored = false;
+        let providerErrored = false;
         try {
             if (resolved.id === 'customAI') {
-                aiErrored = (await translateBatchWithAIAndRender(sourceLanguage, destinationLanguage)) === false;
+                providerErrored = (await translateBatchWithAIAndRender(sourceLanguage, destinationLanguage)) === false;
             } else if (resolved.id === 'dlx' && mode === 'batch') {
-                await translateBatchWithDlx(sourceLanguage, destinationLanguage);
+                providerErrored = (await translateBatchWithDlx(sourceLanguage, destinationLanguage)) === false;
             } else {
                 await translatePerLine(resolved.id, sourceLanguage, destinationLanguage);
             }
         } finally {
             setTranslatingIndicator(false);
         }
-        // Swap the loading dots for an error marker when the AI endpoint
-        // failed, or when the configured provider is misconfigured and this
-        // pass quietly used Google instead — so the user can tell something
-        // is off rather than assuming their provider did the work.
+        // Swap the loading dots for an error marker when the provider's batch
+        // failed (AI or DLX), or when the configured provider is misconfigured
+        // and this pass quietly used Google instead — so the user can tell
+        // something is off rather than assuming their provider did the work.
         if (resolved.fallback) {
             console.warn(`Translatify: provider "${settings.translationProvider}" is missing required settings, used ${resolved.id} instead`);
         }
-        if (aiErrored || resolved.fallback) setTranslateError(true);
+        if (providerErrored || resolved.fallback) setTranslateError(true);
     } else if (translateButton.getAttribute("aria-pressed") == "false") {
         setTranslateError(false);
         restoreLyrics();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -144,6 +144,12 @@ function run() {
             translate();
         }
 
+        if (msgObj.updateDlxTranslationMode) {
+            console.log("Translatify: DLX translation mode updated to", msgObj.updateDlxTranslationMode);
+            restoreLyrics();
+            translate();
+        }
+
         if (msgObj.updateAiThinkMode !== undefined) {
             console.log("Translatify: AI think mode updated to", msgObj.updateAiThinkMode);
             restoreLyrics();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -138,6 +138,12 @@ function run() {
             translate();
         }
 
+        if (msgObj.updateDlxSettings) {
+            console.log("Translatify: DLX settings updated");
+            restoreLyrics();
+            translate();
+        }
+
         if (msgObj.updateAiThinkMode !== undefined) {
             console.log("Translatify: AI think mode updated to", msgObj.updateAiThinkMode);
             restoreLyrics();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -10,10 +10,8 @@ loadChecker();
 run();
 console.log("Translatify: Lyrics Translator is running..");
 
-// Determine the default target language from the browser's preferred languages.
-// navigator.languages / navigator.language are supported on both Chromium and
-// Firefox. The result is normalized to a code the language selector recognizes,
-// and falls back to English when nothing usable is found.
+// Default target language from the browser's preferred languages, normalized
+// to a selector code; falls back to English.
 function getBrowserLanguage() {
     const candidates = [];
     if (Array.isArray(navigator.languages)) candidates.push(...navigator.languages);

--- a/scripts/providers.js
+++ b/scripts/providers.js
@@ -1,0 +1,65 @@
+// Capability registry for translation providers, shared by the popup and the
+// content scripts (loaded before them in both contexts). It drives which
+// settings panel the popup shows, how runTranslate() gates and dispatches, and
+// which storage keys a provider needs — so adding a provider means describing
+// it here (plus a translate function in background.js, which keeps its own map
+// keyed by the same ids) instead of extending if-chains in four files.
+const TRANSLATION_PROVIDERS = {
+    google: {
+        // Needs no configuration; translates line by line only.
+        modes: ['perline'],
+        defaultMode: 'perline',
+        requiredSettings: [],
+        modeSetting: null,
+        panelId: null,
+        buttonClass: null,
+    },
+    dlx: {
+        modes: ['batch', 'perline'],
+        defaultMode: 'batch',
+        requiredSettings: ['dlxEndpoint'],
+        modeSetting: 'dlxTranslationMode',
+        panelId: 'dlxSettings',
+        buttonClass: null,
+    },
+    customAI: {
+        modes: ['batch'],
+        defaultMode: 'batch',
+        requiredSettings: ['aiEndpoint'],
+        modeSetting: null,
+        panelId: 'aiSettings',
+        buttonClass: 'translateButton--ai',
+    },
+};
+
+const FALLBACK_PROVIDER = 'google';
+
+// Every storage key runTranslate() needs to resolve a provider and its mode.
+const PROVIDER_SETTING_KEYS = ['translationProvider', ...Object.values(TRANSLATION_PROVIDERS)
+    .flatMap(spec => [...spec.requiredSettings, spec.modeSetting])
+    .filter(Boolean)];
+
+// The provider actually used for a pass: the configured one when all of its
+// required settings are present, otherwise google. `fallback` is true when the
+// user's choice could not be honored (unknown or misconfigured provider), so
+// callers can surface that instead of silently translating with Google.
+function resolveTranslationProvider(settings) {
+    const requested = settings.translationProvider || FALLBACK_PROVIDER;
+    const spec = TRANSLATION_PROVIDERS[requested];
+    if (spec && !spec.requiredSettings.some(key => !settings[key])) {
+        return { id: requested, spec, fallback: false };
+    }
+    return {
+        id: FALLBACK_PROVIDER,
+        spec: TRANSLATION_PROVIDERS[FALLBACK_PROVIDER],
+        fallback: requested !== FALLBACK_PROVIDER,
+    };
+}
+
+// Effective mode for a resolved provider: the stored choice when the provider
+// supports it, its default otherwise.
+function resolveTranslationMode(resolved, settings) {
+    const { spec } = resolved;
+    const stored = spec.modeSetting ? settings[spec.modeSetting] : null;
+    return spec.modes.includes(stored) ? stored : spec.defaultMode;
+}

--- a/scripts/providers.js
+++ b/scripts/providers.js
@@ -1,9 +1,7 @@
-// Capability registry for translation providers, shared by the popup and the
-// content scripts (loaded before them in both contexts). It drives which
-// settings panel the popup shows, how runTranslate() gates and dispatches, and
-// which storage keys a provider needs — so adding a provider means describing
-// it here (plus a translate function in background.js, which keeps its own map
-// keyed by the same ids) instead of extending if-chains in four files.
+// Capability registry for translation providers, shared by the popup and
+// content scripts. Drives the settings panel, gating/dispatch, and required
+// storage keys. Adding a provider means an entry here plus a translate
+// function in background.js.
 const TRANSLATION_PROVIDERS = {
     google: {
         // Needs no configuration; translates line by line only.
@@ -39,10 +37,9 @@ const PROVIDER_SETTING_KEYS = ['translationProvider', ...Object.values(TRANSLATI
     .flatMap(spec => [...spec.requiredSettings, spec.modeSetting])
     .filter(Boolean)];
 
-// The provider actually used for a pass: the configured one when all of its
-// required settings are present, otherwise google. `fallback` is true when the
-// user's choice could not be honored (unknown or misconfigured provider), so
-// callers can surface that instead of silently translating with Google.
+// The provider used for a pass: the configured one when its required settings
+// are present, otherwise google. `fallback` is true when the user's choice
+// couldn't be honored.
 function resolveTranslationProvider(settings) {
     const requested = settings.translationProvider || FALLBACK_PROVIDER;
     const spec = TRANSLATION_PROVIDERS[requested];

--- a/scripts/translateButton.js
+++ b/scripts/translateButton.js
@@ -25,12 +25,16 @@ function setTranslateError(active) {
     if (loader) loader.classList.toggle("has-error", !!active);
 }
 
-// Toggles the rainbow-hue AI indicator class on the translate button.
-function updateTranslateButtonAIState() {
+// Applies each provider's indicator class from the registry to the translate
+// button (e.g. the rainbow-hue class while Custom AI is selected).
+function updateTranslateButtonProviderState() {
     const translateButton = document.querySelector("button[data-testid='translate-button']");
     if (!translateButton || !isExtensionAlive()) return;
     chrome.storage.local.get(['translationProvider']).then(result => {
-        translateButton.classList.toggle('translateButton--ai', result.translationProvider === 'customAI');
+        for (const [id, spec] of Object.entries(TRANSLATION_PROVIDERS)) {
+            if (!spec.buttonClass) continue;
+            translateButton.classList.toggle(spec.buttonClass, result.translationProvider === id);
+        }
     }).catch(() => {});
 }
 
@@ -45,7 +49,7 @@ function loadChecker() {
         addTranslateButton();
         enableTranslateButton();
         setupListening();
-        updateTranslateButtonAIState();
+        updateTranslateButtonProviderState();
 
         // Check if the translate button was enabled on previous session
         chrome.storage.local.get(["translateButton"]).then((result) => {
@@ -79,7 +83,7 @@ function ensureTranslateButton() {
     eraseButton(); // safety: clear any stale leftover loader
     addTranslateButton();
     enableTranslateButton();
-    updateTranslateButtonAIState();
+    updateTranslateButtonProviderState();
 
     // Re-apply the enabled state from the previous session so the user isn't
     // forced to click the button again after a silent re-inject.
@@ -269,6 +273,6 @@ chrome.runtime.onMessage.addListener(msgObj => {
         }
     }
     if (msgObj.updateTranslationProvider !== undefined || msgObj.updateAiSettings !== undefined) {
-        updateTranslateButtonAIState();
+        updateTranslateButtonProviderState();
     }
 });

--- a/scripts/translateButton.js
+++ b/scripts/translateButton.js
@@ -59,40 +59,166 @@ function loadChecker() {
     }
 }
 
-// Sets up all the event listeners
-function setupListening() {
-    const buttonList = document.querySelectorAll("button");
-    const translateButton = document.querySelector("button[data-testid='translate-button']");
+// Re-entrancy guard for ensureTranslateButton(): several MutationObserver
+// batches can arrive before the first re-inject lands, so collapse them into a
+// single injection. (Note: unlike the old design this no longer rebuilds the
+// observer from inside the callback, so there is no observer-recreate cycle to
+// guard against — this just prevents a double inject race.)
+let ensureInFlight = false;
+
+// Re-injects the translate button if Spotify re-rendered the control bar
+// (e.g. an ad-skip tears the bar down and rebuilds it). Idempotent: it does
+// nothing when the button is already present, so it's safe to call from the
+// observer on every mutation batch. This replaces the previous per-node
+// "self-heal" observers — see setupListening() for why rooting one observer on
+// a stable anchor removes any need to re-attach.
+function ensureTranslateButton() {
+    if (!isExtensionAlive()) return;
+    if (ensureInFlight) return;
+    const existingButton = document.querySelector("button[data-testid='translate-button']");
+    if (existingButton) return; // still present, nothing to do
+
+    const repeatButton = document.querySelector("button[data-testid='control-button-repeat']");
     const lyricsButton = document.querySelector("button[data-testid='lyrics-button']");
-    const nowPlaying = document.querySelector("div[data-testid='now-playing-widget']");
+    if (!repeatButton || !lyricsButton) return; // bar not ready yet
 
-    buttonList.forEach((button) => {
-        button.addEventListener("click", translate);
-        button.addEventListener("click", enableTranslateButton);
-    });
-    
-    translateButton.removeEventListener("change",translate);
-    translateButton.removeEventListener("click",translate);
-    
-    // Listen for changes in the now playing widget
-    var nowPlayingObserver = new MutationObserver(function(mutationsList, nowPlayingObserver) {
-        setTimeout(translate, 100);
-        console.log('Translatify: Next music');
-    });
-    nowPlayingObserver.observe(nowPlaying, { attributes: true});
+    console.log("Translatify: Translate button missing, re-injecting (control bar re-rendered)");
+    ensureInFlight = true;
+    try {
+        eraseButton(); // safety: clear any stale leftover loader
+        addTranslateButton();
+        enableTranslateButton();
+        updateTranslateButtonAIState();
 
-    // Listen for changes in the button bar
-    const rightButtonBar = lyricsButton.parentNode;
-    // Only works on the button bar
-    var rightButtonBarObserver = new MutationObserver(function(mutationsList, rightButtonBarObserver) {
-        console.log('Translatify: Button bar changed');
+        // Re-apply the enabled state from the previous session so the user isn't
+        // forced to click the button again after a silent re-inject.
+        chrome.storage.local.get(["translateButton"]).then((result) => {
+            if (result.translateButton) {
+                toggleTranslateButton();
+            }
+        }).catch(() => {});
+    } finally {
+        ensureInFlight = false;
+    }
+}
+
+// The single, stable observer. Rooted on #main-view (fallback #main / body),
+// which is never torn down by Spotify — only its descendants are. Observing a
+// node that outlives every re-render means the observer never goes stale, so
+// there is nothing to self-heal: missing button, rebuilt control bar, and song
+// changes all surface as childList mutations on the same descendant subtree.
+let listeningObserver = null;
+// Delegated click listener + the anchor it's bound to. Kept as module refs so
+// disconnectTranslateButtonObservers() can remove the handler on teardown —
+// without these, re-calling setupListening() would stack duplicate listeners.
+let listeningAnchor = null;
+let listeningClickHandler = null;
+
+// Cheap dedupe of song-change handling: only re-translate when the now-playing
+// track actually changed, not on every mutation batch (e.g. progress updates).
+let lastNowPlayingKey = '';
+
+// Is idempotent if called repeatedly — see setupListening(). Hold one reference
+// so we can disconnect before re-observing (only relevant if the anchor itself
+// ever changes, e.g. the extension lands on a page without #main-view).
+function setupListening() {
+    if (listeningObserver) return; // already observing — nothing to do
+
+    // Anchor that survives every Spotify re-render. The translate button and
+    // the now-playing widget live somewhere under here, but #main-view itself
+    // stays mounted, so this observer never needs to be re-attached.
+    const anchor = document.querySelector("#main-view") || document.querySelector("#main");
+    if (!anchor) {
+        // #main-view/#main not present yet — defer via a one-shot poll until the
+        // app shell mounts, then install the real observer. Kept simple on
+        // purpose: succeeds quickly on the real Spotify web app. (We deliberately
+        // do NOT fall back to document.body: body was never a useful observer
+        // target here — the branch below only ever retried — and falling back to
+        // it would risk polling forever if the shell never mounts.)
+        return setTimeout(setupListening, 300);
+    }
+
+    // Event delegation: bound once on the stable anchor. The previous design
+    // bound translate/enableTranslateButton directly to each control-bar button
+    // via querySelectorAll('button'), which lost every listener on control-bar
+    // re-renders and forced setupListening() to re-run. A delegated listener on
+    // the anchor survives every re-render because the anchor survives.
+    // (The translate button's own click → toggleTranslateButton is still bound
+    // directly in addTranslateButton(); both paths call translate(), deduped by
+    // translateInFlight.)
+    // Event delegation: bound once on the stable anchor. The previous design
+    // bound translate/enableTranslateButton directly to each control-bar button
+    // via querySelectorAll('button'), which lost every listener on control-bar
+    // re-renders and forced setupListening() to re-run. A delegated listener on
+    // the anchor survives every re-render because the anchor survives.
+    // We only react to clicks that land on a button (closest("button")) so that
+    // clicking track rows, the scrollbar, volume sliders, etc. doesn't fire
+    // enableTranslateButton()/translate() on every interaction across the whole
+    // app. (The translate button's own click → toggleTranslateButton is still
+    // bound directly in addTranslateButton(); both paths call translate(),
+    // deduped by translateInFlight.) The handler and anchor are stored as module
+    // refs so disconnectTranslateButtonObservers() can remove this listener.
+    listeningClickHandler = (event) => {
+        if (event.target.closest("button")) {
+            enableTranslateButton();
+            translate();
+        }
+    };
+    listeningAnchor = anchor;
+    listeningAnchor.addEventListener('click', listeningClickHandler);
+
+    // The previous song-change detection watched the now-playing widget's text,
+    // which fires on every progress tick. getSongInfo() reads the track title
+    // link instead, so the key only changes when the song actually changes.
+    const songChanged = () => {
+        const { songTitle, artistName } = getSongInfo();
+        // Require a valid track title before doing anything: getSongInfo() can
+        // momentarily return empty strings during a track transition or before
+        // metadata loads. Without this guard the key collapses to "|", which is
+        // a truthy string and would slip past a naive !key check, triggering a
+        // redundant translate on every gap.
+        if (!songTitle) return false;
+        const key = `${songTitle}|${artistName}`;
+        if (key === lastNowPlayingKey) return false;
+        lastNowPlayingKey = key;
+        return true;
+    };
+
+    // One observer over the whole subtree, childList only. childList covers:
+    //   - translate button removed/re-added by a control-bar re-render
+    //   - now-playing track title link swapped on song change
+    // We deliberately do NOT watch attributes: the now-playing widget and the
+    // lyrics highlight toggle classes every few hundred ms, which would flood
+    // this callback. childList-only keeps it cheap and targeted.
+    const observer = new MutationObserver(() => {
+        ensureTranslateButton();            // re-inject only if missing (idempotent)
+        if (songChanged()) {
+            setTimeout(translate, 100);     // new song → re-translate lyrics
+        }
         setTimeout(enableTranslateButton, 0);
-        translate();
-        
     });
-    rightButtonBarObserver.observe(rightButtonBar, { subtree: true, childList: true});
+    observer.observe(anchor, { subtree: true, childList: true });
+    listeningObserver = observer;
+    console.log('Translatify: listening on stable anchor', anchor);
+}
 
-
+// Stop observing — used by external callers that previously relied on
+// disconnectTranslateButtonObservers() during cleanup flows. With a single
+// long-lived observer this is rarely needed, but we keep it so call sites that
+// already existed don't break.
+function disconnectTranslateButtonObservers() {
+    if (listeningObserver) {
+        try { listeningObserver.disconnect(); } catch {}
+        listeningObserver = null;
+    }
+    // Remove the delegated click listener too — otherwise a later
+    // setupListening() would bind a second handler on the same anchor and stack
+    // duplicate listeners (memory leak + double-fire translate/enable).
+    if (listeningAnchor && listeningClickHandler) {
+        try { listeningAnchor.removeEventListener("click", listeningClickHandler); } catch {}
+        listeningAnchor = null;
+        listeningClickHandler = null;
+    }
 }
 
 // Translates the lyrics

--- a/scripts/translateButton.js
+++ b/scripts/translateButton.js
@@ -59,22 +59,15 @@ function loadChecker() {
     }
 }
 
-// Re-entrancy guard for ensureTranslateButton(): several MutationObserver
-// batches can arrive before the first re-inject lands, so collapse them into a
-// single injection. (Note: unlike the old design this no longer rebuilds the
-// observer from inside the callback, so there is no observer-recreate cycle to
-// guard against — this just prevents a double inject race.)
-let ensureInFlight = false;
-
 // Re-injects the translate button if Spotify re-rendered the control bar
 // (e.g. an ad-skip tears the bar down and rebuilds it). Idempotent: it does
 // nothing when the button is already present, so it's safe to call from the
-// observer on every mutation batch. This replaces the previous per-node
-// "self-heal" observers — see setupListening() for why rooting one observer on
-// a stable anchor removes any need to re-attach.
+// observer on every mutation batch (the re-inject itself is synchronous, so
+// two batches can never interleave inside it). This replaces the previous
+// per-node "self-heal" observers — see setupListening() for why rooting one
+// observer on a stable anchor removes any need to re-attach.
 function ensureTranslateButton() {
     if (!isExtensionAlive()) return;
-    if (ensureInFlight) return;
     const existingButton = document.querySelector("button[data-testid='translate-button']");
     if (existingButton) return; // still present, nothing to do
 
@@ -83,23 +76,18 @@ function ensureTranslateButton() {
     if (!repeatButton || !lyricsButton) return; // bar not ready yet
 
     console.log("Translatify: Translate button missing, re-injecting (control bar re-rendered)");
-    ensureInFlight = true;
-    try {
-        eraseButton(); // safety: clear any stale leftover loader
-        addTranslateButton();
-        enableTranslateButton();
-        updateTranslateButtonAIState();
+    eraseButton(); // safety: clear any stale leftover loader
+    addTranslateButton();
+    enableTranslateButton();
+    updateTranslateButtonAIState();
 
-        // Re-apply the enabled state from the previous session so the user isn't
-        // forced to click the button again after a silent re-inject.
-        chrome.storage.local.get(["translateButton"]).then((result) => {
-            if (result.translateButton) {
-                toggleTranslateButton();
-            }
-        }).catch(() => {});
-    } finally {
-        ensureInFlight = false;
-    }
+    // Re-apply the enabled state from the previous session so the user isn't
+    // forced to click the button again after a silent re-inject.
+    chrome.storage.local.get(["translateButton"]).then((result) => {
+        if (result.translateButton) {
+            toggleTranslateButton();
+        }
+    }).catch(() => {});
 }
 
 // The single, stable observer. Rooted on #main-view (fallback #main / body),
@@ -108,15 +96,13 @@ function ensureTranslateButton() {
 // there is nothing to self-heal: missing button, rebuilt control bar, and song
 // changes all surface as childList mutations on the same descendant subtree.
 let listeningObserver = null;
-// Delegated click listener + the anchor it's bound to. Kept as module refs so
-// disconnectTranslateButtonObservers() can remove the handler on teardown —
-// without these, re-calling setupListening() would stack duplicate listeners.
-let listeningAnchor = null;
-let listeningClickHandler = null;
 
 // Cheap dedupe of song-change handling: only re-translate when the now-playing
 // track actually changed, not on every mutation batch (e.g. progress updates).
 let lastNowPlayingKey = '';
+
+// Debounce for the untranslated-lyrics catch-up pass scheduled by the observer.
+let retranslatePending = false;
 
 // Is idempotent if called repeatedly — see setupListening(). Hold one reference
 // so we can disconnect before re-observing (only relevant if the anchor itself
@@ -143,29 +129,18 @@ function setupListening() {
     // via querySelectorAll('button'), which lost every listener on control-bar
     // re-renders and forced setupListening() to re-run. A delegated listener on
     // the anchor survives every re-render because the anchor survives.
-    // (The translate button's own click → toggleTranslateButton is still bound
-    // directly in addTranslateButton(); both paths call translate(), deduped by
-    // translateInFlight.)
-    // Event delegation: bound once on the stable anchor. The previous design
-    // bound translate/enableTranslateButton directly to each control-bar button
-    // via querySelectorAll('button'), which lost every listener on control-bar
-    // re-renders and forced setupListening() to re-run. A delegated listener on
-    // the anchor survives every re-render because the anchor survives.
     // We only react to clicks that land on a button (closest("button")) so that
     // clicking track rows, the scrollbar, volume sliders, etc. doesn't fire
     // enableTranslateButton()/translate() on every interaction across the whole
     // app. (The translate button's own click → toggleTranslateButton is still
     // bound directly in addTranslateButton(); both paths call translate(),
-    // deduped by translateInFlight.) The handler and anchor are stored as module
-    // refs so disconnectTranslateButtonObservers() can remove this listener.
-    listeningClickHandler = (event) => {
+    // deduped by translateInFlight.)
+    anchor.addEventListener('click', (event) => {
         if (event.target.closest("button")) {
             enableTranslateButton();
             translate();
         }
-    };
-    listeningAnchor = anchor;
-    listeningAnchor.addEventListener('click', listeningClickHandler);
+    });
 
     // The previous song-change detection watched the now-playing widget's text,
     // which fires on every progress tick. getSongInfo() reads the track title
@@ -195,30 +170,24 @@ function setupListening() {
         if (songChanged()) {
             setTimeout(translate, 100);     // new song → re-translate lyrics
         }
+        // Catch-all for the lyrics view (re)opening: the click-time translate()
+        // runs before Spotify flips the lyrics button's data-active and mounts
+        // the page, so untranslated lines can appear with no other trigger.
+        // Debounced, and cheap when idle: runTranslate() no-ops once every
+        // visible line is translated.
+        if (!retranslatePending) {
+            const translateButton = document.querySelector("button[data-testid='translate-button']");
+            if (translateButton?.getAttribute("aria-pressed") === "true" &&
+                document.querySelector(`${lyricLine}:not(.modifedLyricsWrapper)`)) {
+                retranslatePending = true;
+                setTimeout(() => { retranslatePending = false; translate(); }, 100);
+            }
+        }
         setTimeout(enableTranslateButton, 0);
     });
     observer.observe(anchor, { subtree: true, childList: true });
     listeningObserver = observer;
     console.log('Translatify: listening on stable anchor', anchor);
-}
-
-// Stop observing — used by external callers that previously relied on
-// disconnectTranslateButtonObservers() during cleanup flows. With a single
-// long-lived observer this is rarely needed, but we keep it so call sites that
-// already existed don't break.
-function disconnectTranslateButtonObservers() {
-    if (listeningObserver) {
-        try { listeningObserver.disconnect(); } catch {}
-        listeningObserver = null;
-    }
-    // Remove the delegated click listener too — otherwise a later
-    // setupListening() would bind a second handler on the same anchor and stack
-    // duplicate listeners (memory leak + double-fire translate/enable).
-    if (listeningAnchor && listeningClickHandler) {
-        try { listeningAnchor.removeEventListener("click", listeningClickHandler); } catch {}
-        listeningAnchor = null;
-        listeningClickHandler = null;
-    }
 }
 
 // Translates the lyrics

--- a/scripts/translateButton.js
+++ b/scripts/translateButton.js
@@ -63,13 +63,9 @@ function loadChecker() {
     }
 }
 
-// Re-injects the translate button if Spotify re-rendered the control bar
-// (e.g. an ad-skip tears the bar down and rebuilds it). Idempotent: it does
-// nothing when the button is already present, so it's safe to call from the
-// observer on every mutation batch (the re-inject itself is synchronous, so
-// two batches can never interleave inside it). This replaces the previous
-// per-node "self-heal" observers — see setupListening() for why rooting one
-// observer on a stable anchor removes any need to re-attach.
+// Re-injects the translate button if Spotify re-rendered the control bar.
+// Idempotent — does nothing when the button is already present, so it's safe
+// to call from the observer on every mutation batch.
 function ensureTranslateButton() {
     if (!isExtensionAlive()) return;
     const existingButton = document.querySelector("button[data-testid='translate-button']");
@@ -85,8 +81,7 @@ function ensureTranslateButton() {
     enableTranslateButton();
     updateTranslateButtonProviderState();
 
-    // Re-apply the enabled state from the previous session so the user isn't
-    // forced to click the button again after a silent re-inject.
+    // Re-apply the enabled state from the previous session.
     chrome.storage.local.get(["translateButton"]).then((result) => {
         if (result.translateButton) {
             toggleTranslateButton();
@@ -94,51 +89,30 @@ function ensureTranslateButton() {
     }).catch(() => {});
 }
 
-// The single, stable observer. Rooted on #main-view (fallback #main / body),
-// which is never torn down by Spotify — only its descendants are. Observing a
-// node that outlives every re-render means the observer never goes stale, so
-// there is nothing to self-heal: missing button, rebuilt control bar, and song
-// changes all surface as childList mutations on the same descendant subtree.
+// The single, stable observer, rooted on #main-view (never torn down by
+// Spotify), so it never goes stale.
 let listeningObserver = null;
 
-// Cheap dedupe of song-change handling: only re-translate when the now-playing
-// track actually changed, not on every mutation batch (e.g. progress updates).
+// Last now-playing track key; re-translate only when the song actually changes.
 let lastNowPlayingKey = '';
 
 // Debounce for the untranslated-lyrics catch-up pass scheduled by the observer.
 let retranslatePending = false;
 
-// Is idempotent if called repeatedly — see setupListening(). Hold one reference
-// so we can disconnect before re-observing (only relevant if the anchor itself
-// ever changes, e.g. the extension lands on a page without #main-view).
+// Idempotent if called repeatedly. Holds one observer reference.
 function setupListening() {
     if (listeningObserver) return; // already observing — nothing to do
 
-    // Anchor that survives every Spotify re-render. The translate button and
-    // the now-playing widget live somewhere under here, but #main-view itself
-    // stays mounted, so this observer never needs to be re-attached.
+    // Anchor that survives every Spotify re-render, so the observer never needs
+    // re-attaching.
     const anchor = document.querySelector("#main-view") || document.querySelector("#main");
     if (!anchor) {
-        // #main-view/#main not present yet — defer via a one-shot poll until the
-        // app shell mounts, then install the real observer. Kept simple on
-        // purpose: succeeds quickly on the real Spotify web app. (We deliberately
-        // do NOT fall back to document.body: body was never a useful observer
-        // target here — the branch below only ever retried — and falling back to
-        // it would risk polling forever if the shell never mounts.)
+        // #main-view/#main not present yet — poll until the app shell mounts.
         return setTimeout(setupListening, 300);
     }
 
-    // Event delegation: bound once on the stable anchor. The previous design
-    // bound translate/enableTranslateButton directly to each control-bar button
-    // via querySelectorAll('button'), which lost every listener on control-bar
-    // re-renders and forced setupListening() to re-run. A delegated listener on
-    // the anchor survives every re-render because the anchor survives.
-    // We only react to clicks that land on a button (closest("button")) so that
-    // clicking track rows, the scrollbar, volume sliders, etc. doesn't fire
-    // enableTranslateButton()/translate() on every interaction across the whole
-    // app. (The translate button's own click → toggleTranslateButton is still
-    // bound directly in addTranslateButton(); both paths call translate(),
-    // deduped by translateInFlight.)
+    // Delegated click handler on the stable anchor. Reacts only to clicks that
+    // land on a button, so other interactions don't fire translate().
     anchor.addEventListener('click', (event) => {
         if (event.target.closest("button")) {
             enableTranslateButton();
@@ -146,16 +120,12 @@ function setupListening() {
         }
     });
 
-    // The previous song-change detection watched the now-playing widget's text,
-    // which fires on every progress tick. getSongInfo() reads the track title
-    // link instead, so the key only changes when the song actually changes.
+    // Detect a song change via the track title link, so the key only changes
+    // when the song does.
     const songChanged = () => {
         const { songTitle, artistName } = getSongInfo();
-        // Require a valid track title before doing anything: getSongInfo() can
-        // momentarily return empty strings during a track transition or before
-        // metadata loads. Without this guard the key collapses to "|", which is
-        // a truthy string and would slip past a naive !key check, triggering a
-        // redundant translate on every gap.
+        // Require a valid track title; getSongInfo() can momentarily return
+        // empty strings during a track transition.
         if (!songTitle) return false;
         const key = `${songTitle}|${artistName}`;
         if (key === lastNowPlayingKey) return false;
@@ -163,22 +133,15 @@ function setupListening() {
         return true;
     };
 
-    // One observer over the whole subtree, childList only. childList covers:
-    //   - translate button removed/re-added by a control-bar re-render
-    //   - now-playing track title link swapped on song change
-    // We deliberately do NOT watch attributes: the now-playing widget and the
-    // lyrics highlight toggle classes every few hundred ms, which would flood
-    // this callback. childList-only keeps it cheap and targeted.
+    // One observer over the whole subtree, childList only (attributes would
+    // flood the callback with highlight/progress churn).
     const observer = new MutationObserver(() => {
         ensureTranslateButton();            // re-inject only if missing (idempotent)
         if (songChanged()) {
             setTimeout(translate, 100);     // new song → re-translate lyrics
         }
-        // Catch-all for the lyrics view (re)opening: the click-time translate()
-        // runs before Spotify flips the lyrics button's data-active and mounts
-        // the page, so untranslated lines can appear with no other trigger.
-        // Debounced, and cheap when idle: runTranslate() no-ops once every
-        // visible line is translated.
+        // Catch-all for the lyrics view (re)opening, when untranslated lines
+        // appear with no other trigger. Debounced.
         if (!retranslatePending) {
             const translateButton = document.querySelector("button[data-testid='translate-button']");
             if (translateButton?.getAttribute("aria-pressed") === "true" &&
@@ -236,9 +199,8 @@ function addTranslateButton() {
     translateButton.setAttribute("aria-pressed", "false");
     translateButton.removeAttribute("aria-checked");
     translateButton.setAttribute("role", "button");
-    // Keep all Encore design-system classes from the clone so Spotify's own CSS
-    // handles sizing, padding, and hover states. Only add our marker class and
-    // ensure the button starts in the inactive (subdued) colour state.
+    // Keep the clone's Encore classes so Spotify's CSS styles the button; add
+    // our marker class and start it in the subdued state.
     translateButton.classList.add("translateButton");
     translateButton.classList.remove("encore-internal-color-text-brightAccent");
     if (!translateButton.classList.contains("encore-internal-color-text-subdued")) {


### PR DESCRIPTION
## What this PR does

Adds **DLX** (a [DeepLX](https://github.com/OwO-Network/DeepLX)-compatible endpoint) as a third translation provider alongside Google Translate and Custom AI. DLX needs no API key: the user supplies their own endpoint (self-hosted or a public instance) in the popup. **No default endpoint is bundled** — which server receives lyrics text is an explicit user choice. No `manifest.json` changes were needed; the existing optional host permissions cover user-entered endpoints.

- `dlx` option in the provider dropdown with its own settings panel: endpoint URL, translation mode, and a Test Connection button (accepts both `{data}` and `{translations}` response shapes).
- **Batch by default**: the whole lyric sheet goes out as one request per song (DLX preserves newlines), with an automatic per-line fallback on errors or line-count mismatch. A "Translation Mode" selector lets users pick per-line instead.
- Language mapping from the extension's selector codes to DLX codes (uppercase ISO-639-1, regional variants, and aliases like Filipino→TL, Norwegian→NB, Kurdish→KMR).
- Providers are described once in a capability registry (`scripts/providers.js`) and routed through a single `TRANSLATE { provider, lines }` background message; a misconfigured provider falls back to Google with a visible error marker.
- Locale strings for all 11 locales.
